### PR TITLE
Bump `rand` to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ httparse = { version = "1.8.0", default-features = false, features = ["std"], op
 hyper = { version = "1.2", default-features = false, optional = true }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
 quick-xml = { version = "0.37.0", features = ["serialize", "overlapped-lists"], optional = true }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
+rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"], optional = true }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"], optional = true }
@@ -78,7 +78,7 @@ integration = []
 [dev-dependencies] # In alphabetical order
 hyper = { version = "1.2", features = ["server"] }
 hyper-util = "0.1"
-rand = "0.8"
+rand = "0.9"
 tempfile = "3.1.0"
 regex = "1.11.1"
 # The "gzip" feature for reqwest is enabled for an integration test.

--- a/src/aws/dynamo.rs
+++ b/src/aws/dynamo.rs
@@ -528,8 +528,8 @@ mod tests {
     use super::*;
     use crate::aws::AmazonS3;
     use crate::ObjectStore;
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
+    use rand::distr::Alphanumeric;
+    use rand::{rng, Rng};
 
     #[test]
     fn test_attribute_serde() {
@@ -572,7 +572,7 @@ mod tests {
             _ => panic!("Should conflict"),
         }
 
-        let rng = thread_rng();
+        let rng = rng();
         let etag = String::from_utf8(rng.sample_iter(Alphanumeric).take(32).collect()).unwrap();
         let t = Some(etag.as_str());
 

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -579,7 +579,7 @@ impl AzureClient {
         _part_idx: usize,
         payload: PutPayload,
     ) -> Result<PartId> {
-        let part_idx = u128::from_be_bytes(rand::thread_rng().gen());
+        let part_idx = u128::from_be_bytes(rand::rng().random());
         let content_id = format!("{part_idx:032x}");
         let block_id = BASE64_STANDARD.encode(&content_id);
 

--- a/src/client/backoff.rs
+++ b/src/client/backoff.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use rand::{rng, prelude::*};
+use rand::{prelude::*, rng};
 use std::time::Duration;
 
 /// Exponential backoff with decorrelated jitter algorithm

--- a/src/client/backoff.rs
+++ b/src/client/backoff.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use rand::prelude::*;
+use rand::{rng, prelude::*};
 use std::time::Duration;
 
 /// Exponential backoff with decorrelated jitter algorithm
@@ -78,7 +78,7 @@ impl Backoff {
 
     /// Creates a new `Backoff` with the optional `rng`
     ///
-    /// Used [`rand::thread_rng()`] if no rng provided
+    /// Used [`rand::rng()`] if no rng provided
     pub(crate) fn new_with_rng(
         config: &BackoffConfig,
         rng: Option<Box<dyn RngCore + Sync + Send>>,
@@ -98,8 +98,8 @@ impl Backoff {
         let range = self.init_backoff..(self.next_backoff_secs * self.base);
 
         let rand_backoff = match self.rng.as_mut() {
-            Some(rng) => rng.gen_range(range),
-            None => thread_rng().gen_range(range),
+            Some(rng) => rng.random_range(range),
+            None => rng().random_range(range),
         };
 
         let next_backoff = self.max_backoff_secs.min(rand_backoff);

--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -35,7 +35,7 @@ impl Resolve for ShuffleResolver {
                 let it = (name.as_str(), 0).to_socket_addrs()?;
                 let mut addrs = it.collect::<Vec<_>>();
 
-                addrs.shuffle(&mut rand::thread_rng());
+                addrs.shuffle(&mut rand::rng());
 
                 Ok(Box::new(addrs.into_iter()) as Addrs)
             });

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -35,8 +35,8 @@ use crate::{
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::{StreamExt, TryStreamExt};
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::distr::Alphanumeric;
+use rand::{rng, Rng};
 
 pub(crate) async fn flatten_list_stream(
     storage: &DynObjectStore,
@@ -633,7 +633,7 @@ pub async fn put_opts(storage: &dyn ObjectStore, supports_update: bool) {
     // As a result each conditional operation will need to wait for the lease to timeout before proceeding
     // One solution would be to clear DynamoDB before each test, but this would require non-trivial additional code
     // so we instead just generate a random suffix for the filenames
-    let rng = thread_rng();
+    let rng = rng();
     let suffix = String::from_utf8(rng.sample_iter(Alphanumeric).take(32).collect()).unwrap();
 
     delete_fixtures(storage).await;
@@ -742,10 +742,10 @@ pub async fn put_opts(storage: &dyn ObjectStore, supports_update: bool) {
 /// Returns a chunk of length `chunk_length`
 fn get_chunk(chunk_length: usize) -> Bytes {
     let mut data = vec![0_u8; chunk_length];
-    let mut rng = thread_rng();
+    let mut rng = rng();
     // Set a random selection of bytes
     for _ in 0..1000 {
-        data[rng.gen_range(0..chunk_length)] = rng.gen();
+        data[rng.random_range(0..chunk_length)] = rng.random();
     }
     data.into()
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -312,11 +312,11 @@ mod tests {
                     let mut expected = Vec::with_capacity(1024);
 
                     for _ in 0..50 {
-                        let chunk_size = rng.gen_range(0..30);
-                        let data: Vec<_> = (0..chunk_size).map(|_| rng.gen()).collect();
+                        let chunk_size = rng.random_range(0..30);
+                        let data: Vec<_> = (0..chunk_size).map(|_| rng.random()).collect();
                         expected.extend_from_slice(&data);
 
-                        match rng.gen_bool(method) {
+                        match rng.random_bool(method) {
                             true => write.put(data.into()),
                             false => write.write(&data),
                         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -329,7 +329,7 @@ mod tests {
     use crate::Error;
 
     use super::*;
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
     use std::ops::Range;
 
     /// Calls coalesce_ranges and validates the returned data is correct
@@ -395,20 +395,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_coalesce_fuzz() {
-        let mut rand = thread_rng();
+        let mut rand = rng();
         for _ in 0..100 {
-            let object_len = rand.gen_range(10..250);
-            let range_count = rand.gen_range(0..10);
+            let object_len = rand.random_range(10..250);
+            let range_count = rand.random_range(0..10);
             let ranges: Vec<_> = (0..range_count)
                 .map(|_| {
-                    let start = rand.gen_range(0..object_len);
+                    let start = rand.random_range(0..object_len);
                     let max_len = 20.min(object_len - start);
-                    let len = rand.gen_range(0..max_len);
+                    let len = rand.random_range(0..max_len);
                     start..start + len
                 })
                 .collect();
 
-            let coalesce = rand.gen_range(1..5);
+            let coalesce = rand.random_range(1..5);
             let fetches = do_fetch(ranges.clone(), coalesce).await;
 
             for fetch in fetches.windows(2) {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #5.

# Rationale for this change
 
https://rust-random.github.io/book/update-0.9.html

# What changes are included in this PR?

The required changes to migrate from `0.8` to `0.9`.

# Are there any user-facing changes?

`rand` dependency bumped to `0.9`.