### PR TITLE
Update dependabot config after repo move

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
     open-pull-requests-limit: 10
     target-branch: main
     labels: [ auto-dependencies, arrow ]
-  - package-ecosystem: cargo
-    directory: "/object_store"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    target-branch: main
-    labels: [ auto-dependencies, object_store ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     target-branch: main
-    labels: [ auto-dependencies, arrow ]
+    labels: [ auto-dependencies ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
The dependabot config can be updated.

# What changes are included in this PR?

Removed `/object_store` path config.

# Are there any user-facing changes?

No.