### PR TITLE
feat: make some helpers/utils public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -976,7 +976,7 @@ impl GetOptions {
     /// Returns an error if the modification conditions on this request are not satisfied
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc7232#section-6>
-    fn check_preconditions(&self, meta: &ObjectMeta) -> Result<()> {
+    pub fn check_preconditions(&self, meta: &ObjectMeta) -> Result<()> {
         // The use of the invalid etag "*" means no ETag is equivalent to never matching
         let etag = meta.e_tag.as_deref().unwrap_or("*");
         let last_modified = meta.last_modified;

--- a/src/util.rs
+++ b/src/util.rs
@@ -208,7 +208,8 @@ pub enum GetRange {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum InvalidGetRange {
+#[expect(missing_copy_implementations)] // allow easier extension
+pub enum InvalidGetRange {
     #[error("Wanted range starting at {requested}, but object was only {length} bytes long")]
     StartTooLarge { requested: u64, length: u64 },
 
@@ -220,7 +221,8 @@ pub(crate) enum InvalidGetRange {
 }
 
 impl GetRange {
-    pub(crate) fn is_valid(&self) -> Result<(), InvalidGetRange> {
+    /// Check if the range is valid.
+    pub fn is_valid(&self) -> Result<(), InvalidGetRange> {
         if let Self::Bounded(r) = self {
             if r.end <= r.start {
                 return Err(InvalidGetRange::Inconsistent {
@@ -238,8 +240,8 @@ impl GetRange {
         Ok(())
     }
 
-    /// Convert to a [`Range`] if valid.
-    pub(crate) fn as_range(&self, len: u64) -> Result<Range<u64>, InvalidGetRange> {
+    /// Convert to a [`Range`] if [valid](Self::is_valid).
+    pub fn as_range(&self, len: u64) -> Result<Range<u64>, InvalidGetRange> {
         self.is_valid()?;
         match self {
             Self::Bounded(r) => {


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Makes it easier to implement out-of-tree / 3rd-party stores w/o replicating the code.

# What changes are included in this PR?
- public `GetRange` helpers
- public `GetOptions::check_precondition`

# Are there any user-facing changes?
More public APIs.