### PR TITLE
Enable anonymous access to GCS buckets

### DIFF
--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -632,13 +632,8 @@ impl GetClient for GoogleCloudStorageClient {
             request = request.query(&[("generation", version)]);
         }
 
-        request = request.with_bearer_auth(credential.as_deref());
-
-        // if !credential.bearer.is_empty() {
-        //     request = request.bearer_auth(&credential.bearer);
-        // }
-
         let response = request
+            .with_bearer_auth(credential.as_deref())
             .with_get_options(options)
             .send_retry(&self.config.retry_config)
             .await

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -25,6 +25,7 @@ use crate::client::s3::{
     ListResponse,
 };
 use crate::client::{GetOptionsExt, HttpClient, HttpError, HttpResponse};
+use crate::gcp::credential::CredentialExt;
 use crate::gcp::{GcpCredential, GcpCredentialProvider, GcpSigningCredentialProvider, STORE};
 use crate::multipart::PartId;
 use crate::path::{Path, DELIMITER};
@@ -144,29 +145,20 @@ pub(crate) struct GoogleCloudStorageConfig {
     pub retry_config: RetryConfig,
 
     pub client_options: ClientOptions,
+
+    pub skip_signature: bool,
 }
 
 impl GoogleCloudStorageConfig {
-    pub(crate) fn new(
-        base_url: String,
-        credentials: GcpCredentialProvider,
-        signing_credentials: GcpSigningCredentialProvider,
-        bucket_name: String,
-        retry_config: RetryConfig,
-        client_options: ClientOptions,
-    ) -> Self {
-        Self {
-            base_url,
-            credentials,
-            signing_credentials,
-            bucket_name,
-            retry_config,
-            client_options,
-        }
-    }
-
     pub(crate) fn path_url(&self, path: &Path) -> String {
         format!("{}/{}/{}", self.base_url, self.bucket_name, path)
+    }
+
+    pub(crate) async fn get_credential(&self) -> Result<Option<Arc<GcpCredential>>> {
+        Ok(match self.skip_signature {
+            false => Some(self.credentials.get_credential().await?),
+            true => None,
+        })
     }
 }
 
@@ -304,8 +296,8 @@ impl GoogleCloudStorageClient {
         &self.config
     }
 
-    async fn get_credential(&self) -> Result<Arc<GcpCredential>> {
-        self.config.credentials.get_credential().await
+    async fn get_credential(&self) -> Result<Option<Arc<GcpCredential>>> {
+        self.config.get_credential().await
     }
 
     /// Create a signature from a string-to-sign using Google Cloud signBlob method.
@@ -341,7 +333,7 @@ impl GoogleCloudStorageClient {
         let response = self
             .client
             .post(&url)
-            .bearer_auth(&credential.bearer)
+            .with_bearer_auth(credential.as_deref())
             .json(&body)
             .retryable(&self.config.retry_config)
             .idempotent(true)
@@ -493,7 +485,7 @@ impl GoogleCloudStorageClient {
 
         self.client
             .request(Method::DELETE, &url)
-            .bearer_auth(&credential.bearer)
+            .with_bearer_auth(credential.as_deref())
             .header(CONTENT_TYPE, "application/octet-stream")
             .header(CONTENT_LENGTH, "0")
             .query(&[("uploadId", multipart_id)])
@@ -538,7 +530,7 @@ impl GoogleCloudStorageClient {
         let response = self
             .client
             .request(Method::POST, &url)
-            .bearer_auth(&credential.bearer)
+            .with_bearer_auth(credential.as_deref())
             .query(&[("uploadId", upload_id)])
             .body(data)
             .retryable(&self.config.retry_config)
@@ -594,7 +586,7 @@ impl GoogleCloudStorageClient {
         }
 
         builder
-            .bearer_auth(&credential.bearer)
+            .with_bearer_auth(credential.as_deref())
             // Needed if reqwest is compiled with native-tls instead of rustls-tls
             // See https://github.com/apache/arrow-rs/pull/3921
             .header(CONTENT_LENGTH, 0)
@@ -640,9 +632,11 @@ impl GetClient for GoogleCloudStorageClient {
             request = request.query(&[("generation", version)]);
         }
 
-        if !credential.bearer.is_empty() {
-            request = request.bearer_auth(&credential.bearer);
-        }
+        request = request.with_bearer_auth(credential.as_deref());
+
+        // if !credential.bearer.is_empty() {
+        //     request = request.bearer_auth(&credential.bearer);
+        // }
 
         let response = request
             .with_get_options(options)
@@ -696,7 +690,7 @@ impl ListClient for Arc<GoogleCloudStorageClient> {
             .client
             .request(Method::GET, url)
             .query(&query)
-            .bearer_auth(&credential.bearer)
+            .with_bearer_auth(credential.as_deref())
             .send_retry(&self.config.retry_config)
             .await
             .map_err(|source| Error::ListRequest { source })?

--- a/src/gcp/credential.rs
+++ b/src/gcp/credential.rs
@@ -863,7 +863,13 @@ pub(crate) trait CredentialExt {
 impl CredentialExt for HttpRequestBuilder {
     fn with_bearer_auth(self, credential: Option<&GcpCredential>) -> Self {
         match credential {
-            Some(credential) => self.bearer_auth(&credential.bearer),
+            Some(credential) => {
+                if credential.bearer.is_empty() {
+                    self
+                } else {
+                    self.bearer_auth(&credential.bearer)
+                }
+            }
             None => self,
         }
     }

--- a/src/gcp/credential.rs
+++ b/src/gcp/credential.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use super::client::GoogleCloudStorageClient;
+use crate::client::builder::HttpRequestBuilder;
 use crate::client::retry::RetryExt;
 use crate::client::token::TemporaryToken;
 use crate::client::{HttpClient, HttpError, TokenProvider};
@@ -424,7 +425,7 @@ impl TokenProvider for InstanceCredentialProvider {
     /// Since the connection is local we need to enable http access and don't actually use the client object passed in.
     /// Respects the `GCE_METADATA_HOST`, `GCE_METADATA_ROOT`, and `GCE_METADATA_IP`
     /// environment variables.
-    ///  
+    ///
     /// References: <https://googleapis.dev/python/google-auth/latest/reference/google.auth.environment_vars.html>
     async fn fetch_token(
         &self,
@@ -494,7 +495,7 @@ impl TokenProvider for InstanceSigningCredentialProvider {
     /// Since the connection is local we need to enable http access and don't actually use the client object passed in.
     /// Respects the `GCE_METADATA_HOST`, `GCE_METADATA_ROOT`, and `GCE_METADATA_IP`
     /// environment variables.
-    ///  
+    ///
     /// References: <https://googleapis.dev/python/google-auth/latest/reference/google.auth.environment_vars.html>
     async fn fetch_token(
         &self,
@@ -851,6 +852,20 @@ impl GCSAuthorizer {
             scope,
             hashed_canonical_req
         )
+    }
+}
+
+pub(crate) trait CredentialExt {
+    /// Apply bearer authentication to the request if the credential is not None
+    fn with_bearer_auth(self, credential: Option<&GcpCredential>) -> Self;
+}
+
+impl CredentialExt for HttpRequestBuilder {
+    fn with_bearer_auth(self, credential: Option<&GcpCredential>) -> Self {
+        match credential {
+            Some(credential) => self.bearer_auth(&credential.bearer),
+            None => self,
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs-object-store/issues/302.

# Rationale for this change

# What changes are included in this PR?

- Add `skip_signature` config parameter
- Add `with_skip_signature` to `GoogleCloudStorageBuilder`
- Add `CredentialExt` in `src/gcp/credential.rs`, similar to what already exists for AWS in `src/aws/credential.rs`. This allows for easily calling `with_bearer_auth` in the request builder chain without having to do an `if/else` to handle `credentials` being `None` there.

**Questions**

- How should I test this? I looked for other existing tests for `skip_signature` and it looks like the one existing one for AWS is ignored: https://github.com/apache/arrow-rs-object-store/blob/e975177814778b711e11b048bb5c703d2b893427/src/aws/mod.rs#L690-L714

I was able to successfully test this in the obstore Python bindings (https://github.com/developmentseed/obstore/pull/404) on a GCP open data bucket:


```py
store = GCSStore("gcp-public-data-arco-era5", skip_signature=True)
```

```py
next(store.list())
# [{'path': 'ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/.zattrs',
#   'last_modified': datetime.datetime(2023, 9, 14, 7, 6, 30, 187000, tzinfo=datetime.timezone.utc),
#   'size': 2,
#   'e_tag': '"99914b932bd37a50b983c5e7c90ae93b"',
#   'version': None},
#  {'path': 'ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/.zgroup',
#   'last_modified': datetime.datetime(2023, 9, 14, 7, 6, 28, 987000, tzinfo=datetime.timezone.utc),
#   'size': 24,
#   'e_tag': '"e20297935e73dd0154104d4ea53040ab"',
#   'version': None},
# ...

orjson.loads(
    memoryview(
        store.get(
            "ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/.zmetadata",
        ).bytes()
    ),
)

# {'metadata': {'.zattrs': {},
#   '.zgroup': {'zarr_format': 2},
#   '10m_u_component_of_wind/.zarray': {'chunks': [8, 240, 121],
#    'compressor': {'blocksize': 0,
#     'clevel': 5,
#     'cname': 'lz4',
#     'id': 'blosc',
#     'shuffle': 1},
#    'dtype': '<f4',
#    'fill_value': 'NaN',
#    'filters': None,
#    'order': 'C',
#    'shape': [552264, 240, 121],
#    'zarr_format': 2},
#   '10m_u_component_of_wind/.zattrs': {'_ARRAY_DIMENSIONS': ['time',
#     'longitude',
#     'latitude'],
#    'long_name': '10 metre U wind component',
#    'short_name': 'u10',
#    'units': 'm s**-1'},
# ...
```

(cc @paraseba @tomnicholas @maxrjones)

# Are there any user-facing changes?

Adds `skip_signature`.
