### PR TITLE
feat: support list with ListOpts which contains the offset, max_keys,…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-ut
 nix = { version = "0.29.0", features = ["fs"] }
 
 [features]
-default = ["fs"]
+default = ["fs", "aws"]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded"]
 azure = ["cloud", "httparse"]
 fs = ["walkdir"]

--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -173,6 +173,8 @@ pub struct AmazonS3Builder {
     request_payer: ConfigValue<bool>,
     /// The [`HttpConnector`] to use
     http_connector: Option<Arc<dyn HttpConnector>>,
+    /// Max list size per request, by default 1000.
+    max_list_size_per_request: Option<ConfigValue<usize>>,
 }
 
 /// Configuration keys for [`AmazonS3Builder`]
@@ -891,6 +893,12 @@ impl AmazonS3Builder {
         self
     }
 
+    /// Set the max keys per list request. It's almost used for test paginated listing.
+    pub fn with_max_list_size_per_request(mut self, max_list_size_per_request: usize) -> Self {
+        self.max_list_size_per_request = Some(ConfigValue::Parsed(max_list_size_per_request));
+        self
+    }
+
     /// Create a [`AmazonS3`] instance from the provided values,
     /// consuming `self`.
     pub fn build(mut self) -> Result<AmazonS3> {
@@ -1029,6 +1037,10 @@ impl AmazonS3Builder {
             S3EncryptionHeaders::default()
         };
 
+        let max_list_size_per_request = self
+            .max_list_size_per_request
+            .unwrap_or(ConfigValue::Parsed(1000))
+            .get()?;
         let config = S3Config {
             region,
             endpoint: self.endpoint,
@@ -1046,6 +1058,7 @@ impl AmazonS3Builder {
             conditional_put: self.conditional_put.get()?,
             encryption_headers,
             request_payer: self.request_payer.get()?,
+            max_list_keys_per_request: max_list_size_per_request,
         };
 
         let http_client = http.connect(&config.client_options)?;

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -316,7 +316,6 @@ impl ObjectStore for AmazonS3 {
                                 .filter(|p| p > &offset)
                                 .collect();
                             ListResult {
-                                key_count: objects.len() + common_prefixes.len(),
                                 common_prefixes,
                                 objects,
                             }

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -317,7 +317,6 @@ impl ObjectStore for AmazonS3 {
                                 .collect();
                             ListResult {
                                 key_count: objects.len() + common_prefixes.len(),
-                                is_truncated: r.is_truncated,
                                 common_prefixes,
                                 objects,
                             }

--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -1038,7 +1038,11 @@ impl MicrosoftAzureBuilder {
             (false, url, credential, account_name)
         };
 
-        let max_list_keys_per_request = self.max_list_size_per_request.unwrap_or(ConfigValue::Parsed(1000)).get()?;
+        let max_list_keys_per_request = self
+            .max_list_size_per_request
+            .unwrap_or(ConfigValue::Parsed(1000))
+            .get()?;
+
         let config = AzureConfig {
             account,
             is_emulator,

--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -180,6 +180,8 @@ pub struct MicrosoftAzureBuilder {
     fabric_cluster_identifier: Option<String>,
     /// The [`HttpConnector`] to use
     http_connector: Option<Arc<dyn HttpConnector>>,
+    /// Max list size per request, by default 1000.
+    max_list_size_per_request: Option<ConfigValue<usize>>,
 }
 
 /// Configuration keys for [`MicrosoftAzureBuilder`]
@@ -897,6 +899,12 @@ impl MicrosoftAzureBuilder {
         self
     }
 
+    /// Set the max keys per list request. It's almost used for test paginated listing.
+    pub fn with_max_list_size_per_request(mut self, max_list_size_per_request: usize) -> Self {
+        self.max_list_size_per_request = Some(ConfigValue::Parsed(max_list_size_per_request));
+        self
+    }
+
     /// Configure a connection to container with given name on Microsoft Azure Blob store.
     pub fn build(mut self) -> Result<MicrosoftAzure> {
         if let Some(url) = self.url.take() {
@@ -1030,6 +1038,7 @@ impl MicrosoftAzureBuilder {
             (false, url, credential, account_name)
         };
 
+        let max_list_keys_per_request = self.max_list_size_per_request.unwrap_or(ConfigValue::Parsed(1000)).get()?;
         let config = AzureConfig {
             account,
             is_emulator,
@@ -1040,6 +1049,7 @@ impl MicrosoftAzureBuilder {
             client_options: self.client_options,
             service: storage_url,
             credentials: auth,
+            max_list_keys_per_request,
         };
 
         let http_client = http.connect(&config.client_options)?;

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -1059,7 +1059,6 @@ fn to_list_result(value: ListResultInternal, prefix: Option<&str>) -> Result<Lis
         .collect::<Result<_>>()?;
 
     Ok(ListResult {
-        key_count: 0,
         common_prefixes,
         objects,
     })

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -1060,7 +1060,6 @@ fn to_list_result(value: ListResultInternal, prefix: Option<&str>) -> Result<Lis
 
     Ok(ListResult {
         key_count: 0,
-        is_truncated: false,
         common_prefixes,
         objects,
     })

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     multipart::{MultipartStore, PartId},
     path::Path,
     signer::Signer,
-    GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, UploadPart,
+    GetOptions, GetResult, ListOpts, ListResult, MultipartId, MultipartUpload,
+    ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, UploadPart,
 };
 use async_trait::async_trait;
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
@@ -119,9 +119,6 @@ impl ObjectStore for MicrosoftAzure {
         self.client.delete_request(location, &()).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
-        self.client.list(prefix)
-    }
     fn delete_stream<'a>(
         &'a self,
         locations: BoxStream<'a, Result<Path>>,
@@ -142,8 +139,12 @@ impl ObjectStore for MicrosoftAzure {
             .boxed()
     }
 
-    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
-        self.client.list_with_delimiter(prefix).await
+    fn list_opts(
+        &self,
+        prefix: Option<&Path>,
+        options: ListOpts,
+    ) -> BoxStream<'static, Result<ListResult>> {
+        self.client.list_paginated(prefix, options)
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -28,8 +28,8 @@ use futures::StreamExt;
 
 use crate::path::Path;
 use crate::{
-    GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOpts, PutOptions, PutResult,
+    GetOptions, GetResult, GetResultPayload, ListOpts, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOpts, PutOptions, PutResult,
 };
 use crate::{PutPayload, Result};
 
@@ -150,16 +150,12 @@ impl ObjectStore for ChunkedStore {
         self.inner.delete(location).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
-        self.inner.list(prefix)
-    }
-
-    fn list_with_offset(
+    fn list_opts(
         &self,
         prefix: Option<&Path>,
-        offset: &Path,
-    ) -> BoxStream<'static, Result<ObjectMeta>> {
-        self.inner.list_with_offset(prefix, offset)
+        options: ListOpts,
+    ) -> BoxStream<'static, Result<ListResult>> {
+        self.inner.list_opts(prefix, options)
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {

--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -80,7 +80,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
                         extensions.clone(),
                     )
                     .await?;
-                let remaining = max_keys.map(|x| x - r.key_count);
+                let key_count = r.common_prefixes.len() + r.objects.len();
+                let remaining = max_keys.map(|x| x - key_count);
                 let next_token = match remaining {
                     None => next_token,
                     Some(remaining) if remaining > 0 => next_token,

--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -26,6 +26,10 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "PascalCase")]
 pub struct ListResponse {
     #[serde(default)]
+    pub key_count: usize,
+    #[serde(default)]
+    pub is_truncated: bool,
+    #[serde(default)]
     pub contents: Vec<ListContents>,
     #[serde(default)]
     pub common_prefixes: Vec<ListPrefix>,
@@ -50,6 +54,8 @@ impl TryFrom<ListResponse> for ListResult {
             .collect::<Result<_>>()?;
 
         Ok(Self {
+            key_count: value.key_count,
+            is_truncated: value.is_truncated,
             common_prefixes,
             objects,
         })

--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -26,10 +26,6 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "PascalCase")]
 pub struct ListResponse {
     #[serde(default)]
-    pub key_count: usize,
-    #[serde(default)]
-    pub is_truncated: bool,
-    #[serde(default)]
     pub contents: Vec<ListContents>,
     #[serde(default)]
     pub common_prefixes: Vec<ListPrefix>,

--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -54,7 +54,6 @@ impl TryFrom<ListResponse> for ListResult {
             .collect::<Result<_>>()?;
 
         Ok(Self {
-            key_count: value.key_count,
             common_prefixes,
             objects,
         })

--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -55,7 +55,6 @@ impl TryFrom<ListResponse> for ListResult {
 
         Ok(Self {
             key_count: value.key_count,
-            is_truncated: value.is_truncated,
             common_prefixes,
             objects,
         })

--- a/src/gcp/builder.rs
+++ b/src/gcp/builder.rs
@@ -31,7 +31,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
-
 use super::credential::{AuthorizedUserSigningCredentials, InstanceSigningCredentialProvider};
 
 const TOKEN_MIN_TTL: Duration = Duration::from_secs(4 * 60);
@@ -113,6 +112,8 @@ pub struct GoogleCloudStorageBuilder {
     signing_credentials: Option<GcpSigningCredentialProvider>,
     /// The [`HttpConnector`] to use
     http_connector: Option<Arc<dyn HttpConnector>>,
+    /// Max list size per request, by default 1000.
+    max_list_size_per_request: Option<usize>,
 }
 
 /// Configuration keys for [`GoogleCloudStorageBuilder`]
@@ -210,6 +211,7 @@ impl Default for GoogleCloudStorageBuilder {
             credentials: None,
             signing_credentials: None,
             http_connector: None,
+            max_list_size_per_request: Some(1000),
         }
     }
 }
@@ -435,6 +437,12 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
+    /// Set the max keys per list request. It's almost used for test paginated listing.
+    pub fn with_max_list_size_per_request(mut self, max_list_size_per_request: usize) -> Self {
+        self.max_list_size_per_request = Some(max_list_size_per_request);
+        self
+    }
+
     /// Configure a connection to Google Cloud Storage, returning a
     /// new [`GoogleCloudStorage`] and consuming `self`
     pub fn build(mut self) -> Result<GoogleCloudStorage> {
@@ -553,6 +561,7 @@ impl GoogleCloudStorageBuilder {
             bucket_name,
             self.retry_config,
             self.client_options,
+            self.max_list_size_per_request.unwrap_or(1000)
         );
 
         let http_client = http.connect(&config.client_options)?;

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -144,6 +144,8 @@ pub(crate) struct GoogleCloudStorageConfig {
     pub retry_config: RetryConfig,
 
     pub client_options: ClientOptions,
+
+    pub max_list_keys_per_request: usize,
 }
 
 impl GoogleCloudStorageConfig {
@@ -154,6 +156,7 @@ impl GoogleCloudStorageConfig {
         bucket_name: String,
         retry_config: RetryConfig,
         client_options: ClientOptions,
+        max_list_keys_per_request: usize,
     ) -> Self {
         Self {
             base_url,
@@ -162,6 +165,7 @@ impl GoogleCloudStorageConfig {
             bucket_name,
             retry_config,
             client_options,
+            max_list_keys_per_request,
         }
     }
 
@@ -666,11 +670,13 @@ impl ListClient for Arc<GoogleCloudStorageClient> {
         delimiter: bool,
         page_token: Option<&str>,
         offset: Option<&str>,
+        max_keys: Option<usize>,
+        extensions: ::http::Extensions,
     ) -> Result<(ListResult, Option<String>)> {
         let credential = self.get_credential().await?;
         let url = format!("{}/{}", self.config.base_url, self.bucket_name_encoded);
 
-        let mut query = Vec::with_capacity(5);
+        let mut query = Vec::with_capacity(7);
         query.push(("list-type", "2"));
         if delimiter {
             query.push(("delimiter", DELIMITER))
@@ -692,11 +698,18 @@ impl ListClient for Arc<GoogleCloudStorageClient> {
             query.push(("start-after", offset))
         }
 
+        let max_keys = max_keys
+            .map(|x| x.min(self.config.max_list_keys_per_request))
+            .unwrap_or(self.config.max_list_keys_per_request)
+            .to_string();
+        query.push(("max-keys", max_keys.as_str()));
+
         let response = self
             .client
             .request(Method::GET, url)
             .query(&query)
             .bearer_auth(&credential.bearer)
+            .extensions(extensions)
             .send_retry(&self.config.retry_config)
             .await
             .map_err(|source| Error::ListRequest { source })?

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -262,6 +262,7 @@ impl Signer for GoogleCloudStorage {
 
 #[cfg(test)]
 mod test {
+
     use credential::DEFAULT_GCS_BASE_URL;
 
     use crate::integration::*;

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -41,9 +41,9 @@ use crate::client::CredentialProvider;
 use crate::gcp::credential::GCSAuthorizer;
 use crate::signer::Signer;
 use crate::{
-    multipart::PartId, path::Path, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload,
-    ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
-    UploadPart,
+    multipart::PartId, path::Path, GetOptions, GetResult, ListOpts, ListResult, MultipartId,
+    MultipartUpload, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
+    Result, UploadPart,
 };
 use async_trait::async_trait;
 use client::GoogleCloudStorageClient;
@@ -183,20 +183,12 @@ impl ObjectStore for GoogleCloudStorage {
         self.client.delete_request(location).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
-        self.client.list(prefix)
-    }
-
-    fn list_with_offset(
+    fn list_opts(
         &self,
         prefix: Option<&Path>,
-        offset: &Path,
-    ) -> BoxStream<'static, Result<ObjectMeta>> {
-        self.client.list_with_offset(prefix, offset)
-    }
-
-    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
-        self.client.list_with_delimiter(prefix).await
+        options: ListOpts,
+    ) -> BoxStream<'static, Result<ListResult>> {
+        self.client.list_paginated(prefix, options)
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
@@ -270,7 +262,6 @@ impl Signer for GoogleCloudStorage {
 
 #[cfg(test)]
 mod test {
-
     use credential::DEFAULT_GCS_BASE_URL;
 
     use crate::integration::*;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -244,7 +244,7 @@ impl ObjectStore for HttpStore {
                         Ok(None)
                     } else {
                         let key_count = buffer.len();
-                        let remaining = max_keys.map(|x| x - key_count);
+                        let remaining = max_keys.map(|x| (x - key_count).max(0));
                         let result = ListResult {
                             common_prefixes: vec![],
                             objects: buffer,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -216,9 +216,7 @@ impl ObjectStore for HttpStore {
                     }
                 }
 
-                let resp_key_count = common_prefixes.len() + objects.len();
                 Ok(ListResult {
-                    key_count: resp_key_count,
                     common_prefixes,
                     objects,
                 })
@@ -248,7 +246,6 @@ impl ObjectStore for HttpStore {
                         let key_count = buffer.len();
                         let remaining = max_keys.map(|x| x - key_count);
                         let result = ListResult {
-                            key_count: buffer.len(),
                             common_prefixes: vec![],
                             objects: buffer,
                         };
@@ -287,7 +284,6 @@ impl ObjectStore for HttpStore {
         }
 
         Ok(ListResult {
-            key_count: common_prefixes.len() + objects.len(),
             common_prefixes,
             objects,
         })

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -219,7 +219,6 @@ impl ObjectStore for HttpStore {
                 let resp_key_count = common_prefixes.len() + objects.len();
                 Ok(ListResult {
                     key_count: resp_key_count,
-                    is_truncated: resp_key_count < key_count,
                     common_prefixes,
                     objects,
                 })
@@ -250,7 +249,6 @@ impl ObjectStore for HttpStore {
                         let remaining = max_keys.map(|x| x - key_count);
                         let result = ListResult {
                             key_count: buffer.len(),
-                            is_truncated: false,
                             common_prefixes: vec![],
                             objects: buffer,
                         };
@@ -290,7 +288,6 @@ impl ObjectStore for HttpStore {
 
         Ok(ListResult {
             key_count: common_prefixes.len() + objects.len(),
-            is_truncated: false,
             common_prefixes,
             objects,
         })

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1000,7 +1000,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
     let result = stream.next().await.unwrap().unwrap();
     assert_eq!(result.common_prefixes.len(), 0);
     assert_eq!(result.objects.len(), 5);
-    assert!(!result.is_truncated);
     assert_eq!(result.key_count, 5);
     assert!(stream.next().await.is_none());
 
@@ -1033,7 +1032,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
         result.objects[1].location,
         Path::from("mydb/wb/000/000/001.segment")
     );
-    assert!(!result.is_truncated);
     assert_eq!(result.key_count, 2);
     assert!(stream.next().await.is_none());
 
@@ -1053,7 +1051,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
     );
     assert_eq!(result.objects.len(), 1);
     assert_eq!(result.objects[0].location, expected_location);
-    assert!(!result.is_truncated);
     assert_eq!(result.key_count, 3);
     assert!(stream.next().await.is_none());
 
@@ -1073,7 +1070,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
         vec![expected_000.clone(), expected_001.clone()]
     );
     assert_eq!(result.objects.len(), 0);
-    assert!(result.is_truncated);
     assert_eq!(result.key_count, 2);
     assert!(stream.next().await.is_none());
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1000,7 +1000,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
     let result = stream.next().await.unwrap().unwrap();
     assert_eq!(result.common_prefixes.len(), 0);
     assert_eq!(result.objects.len(), 5);
-    assert_eq!(result.key_count, 5);
     assert!(stream.next().await.is_none());
 
     // =========== check: prefix-list `mydb/wb` (directory) with max_keys=0 ==============
@@ -1032,7 +1031,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
         result.objects[1].location,
         Path::from("mydb/wb/000/000/001.segment")
     );
-    assert_eq!(result.key_count, 2);
     assert!(stream.next().await.is_none());
 
     // =========== check: prefix-list `mydb/wb` (directory) with delimiter ==============
@@ -1051,7 +1049,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
     );
     assert_eq!(result.objects.len(), 1);
     assert_eq!(result.objects[0].location, expected_location);
-    assert_eq!(result.key_count, 3);
     assert!(stream.next().await.is_none());
 
     // ===== check: prefix-list `mydb/wb` (directory) with delimiter & max_keys=2 =========
@@ -1070,7 +1067,6 @@ pub async fn list_with_composite_conditions(storage: &DynObjectStore) {
         vec![expected_000.clone(), expected_001.clone()]
     );
     assert_eq!(result.objects.len(), 0);
-    assert_eq!(result.key_count, 2);
     assert!(stream.next().await.is_none());
 
     // ==================== do: remove all files ====================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,19 +779,16 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
         let mut common_prefixes = BTreeSet::new();
         let mut objects = Vec::new();
         let mut count = 0;
-        let mut is_truncated = true;
 
         while let Some(result) = stream.next().await {
             let response = result?;
             common_prefixes.extend(response.common_prefixes.into_iter());
             objects.extend(response.objects.into_iter());
             count += response.key_count;
-            is_truncated = response.is_truncated;
         }
 
         Ok(ListResult {
             key_count: count,
-            is_truncated,
             common_prefixes: common_prefixes.into_iter().collect(),
             objects,
         })
@@ -948,8 +945,6 @@ as_ref_impl!(Box<dyn ObjectStore>);
 pub struct ListResult {
     /// Total object number in the result set
     pub key_count: usize,
-    /// Indicates whether the object store returned all results that satisfied the request.
-    pub is_truncated: bool,
     /// Prefixes that are common (like directories)
     pub common_prefixes: Vec<Path>,
     /// Object metadata for the listing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,6 +946,16 @@ pub struct ListResult {
     pub objects: Vec<ObjectMeta>,
 }
 
+impl ListResult {
+    /// Create a list rust with empty content.
+    pub fn empty() -> Self {
+        Self {
+            common_prefixes: Vec::new(),
+            objects: Vec::new(),
+        }
+    }
+}
+
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectMeta {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,17 +778,14 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
 
         let mut common_prefixes = BTreeSet::new();
         let mut objects = Vec::new();
-        let mut count = 0;
 
         while let Some(result) = stream.next().await {
             let response = result?;
             common_prefixes.extend(response.common_prefixes.into_iter());
             objects.extend(response.objects.into_iter());
-            count += response.key_count;
         }
 
         Ok(ListResult {
-            key_count: count,
             common_prefixes: common_prefixes.into_iter().collect(),
             objects,
         })
@@ -943,8 +940,6 @@ as_ref_impl!(Box<dyn ObjectStore>);
 /// 1,000 objects based on the underlying object storage's limitations.
 #[derive(Debug)]
 pub struct ListResult {
-    /// Total object number in the result set
-    pub key_count: usize,
     /// Prefixes that are common (like directories)
     pub common_prefixes: Vec<Path>,
     /// Object metadata for the listing

--- a/src/local.rs
+++ b/src/local.rs
@@ -673,7 +673,7 @@ impl LocalFileSystem {
                     }
 
                     let key_count = common_prefixes.len() + objects.len();
-                    let remaining = max_keys.map(|x| x - key_count);
+                    let remaining = max_keys.map(|x| (x - key_count).max(0));
                     Ok(Some((
                         ListResult {
                             common_prefixes: common_prefixes.into_iter().collect(),
@@ -693,7 +693,7 @@ impl LocalFileSystem {
                     }
 
                     let key_count = objects.len();
-                    let remaining = max_keys.map(|x| x - key_count);
+                    let remaining = max_keys.map(|x| (x - key_count).max(0));
                     Ok(Some((
                         ListResult {
                             common_prefixes: vec![],

--- a/src/local.rs
+++ b/src/local.rs
@@ -652,7 +652,6 @@ impl LocalFileSystem {
                     let remaining = max_keys.map(|x| x - key_count);
 
                     let result = ListResult {
-                        key_count,
                         common_prefixes: vec![],
                         objects,
                     };
@@ -758,7 +757,6 @@ impl LocalFileSystem {
                     let remaining = max_keys.map(|x| x - key_count);
 
                     let result = ListResult {
-                        key_count,
                         common_prefixes: common_prefixes.into_iter().collect(),
                         objects,
                     };

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -396,7 +396,6 @@ impl ObjectStore for InMemory {
         }
 
         Ok(ListResult {
-            key_count: objects.len() + common_prefixes.len(),
             objects,
             common_prefixes: common_prefixes.into_iter().collect(),
         })
@@ -486,7 +485,6 @@ impl InMemory {
         }
 
         let result = Ok(ListResult {
-            key_count,
             objects,
             common_prefixes: common_prefixes.into_iter().collect(),
         });
@@ -535,7 +533,6 @@ impl InMemory {
         } else {
             futures::stream::once(async {
                 Ok(ListResult {
-                    key_count: objects.len(),
                     objects,
                     common_prefixes: vec![],
                 })

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -401,11 +401,6 @@ impl InMemory {
             }
         }
 
-        let key_count = objects.len() + common_prefixes.len();
-        if key_count == 0 {
-            return futures::stream::iter(vec![]).boxed();
-        }
-
         let result = Ok(ListResult {
             objects,
             common_prefixes: common_prefixes.into_iter().collect(),
@@ -450,17 +445,13 @@ impl InMemory {
             _ => values,
         };
 
-        if objects.is_empty() {
-            futures::stream::iter(vec![]).boxed()
-        } else {
-            futures::stream::once(async {
-                Ok(ListResult {
-                    objects,
-                    common_prefixes: vec![],
-                })
+        futures::stream::once(async {
+            Ok(ListResult {
+                objects,
+                common_prefixes: vec![],
             })
-            .boxed()
-        }
+        })
+        .boxed()
     }
 }
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -182,7 +182,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
 
         s.map_ok(move |lst| ListResult {
             key_count: lst.key_count,
-            is_truncated: lst.is_truncated,
             common_prefixes: lst
                 .common_prefixes
                 .into_iter()
@@ -216,7 +215,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
             .await
             .map(|lst| ListResult {
                 key_count: lst.key_count,
-                is_truncated: lst.is_truncated,
                 common_prefixes: lst
                     .common_prefixes
                     .into_iter()

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -181,7 +181,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         let s = self.inner.list_opts(Some(&prefix), opts);
 
         s.map_ok(move |lst| ListResult {
-            key_count: lst.key_count,
             common_prefixes: lst
                 .common_prefixes
                 .into_iter()
@@ -214,7 +213,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
             .list_with_delimiter(Some(&prefix))
             .await
             .map(|lst| ListResult {
-                key_count: lst.key_count,
                 common_prefixes: lst
                     .common_prefixes
                     .into_iter()

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -171,9 +171,9 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         options: ListOpts,
     ) -> BoxStream<'static, Result<ListResult>> {
         let prefix = self.full_path(prefix.unwrap_or(&Path::default()));
-        let offset = self.full_path(options.offset.as_ref().unwrap_or(&Path::default()));
+        let offset = options.offset.map(|p| self.full_path(&p));
         let opts = ListOpts {
-            offset: Some(offset),
+            offset,
             delimiter: options.delimiter,
             max_keys: options.max_keys,
             extensions: options.extensions,

--- a/tests/get_range_file.rs
+++ b/tests/get_range_file.rs
@@ -66,6 +66,10 @@ impl ObjectStore for MyStore {
         todo!()
     }
 
+    fn list_opts(&self, _: Option<&Path>, _: ListOpts) -> BoxStream<'static, Result<ListResult>> {
+        todo!()
+    }
+
     async fn list_with_delimiter(&self, _: Option<&Path>) -> Result<ListResult> {
         todo!()
     }


### PR DESCRIPTION
… delimiter

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #295 and #291.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- add a `list_opts` method in `ObjectStore` traits and implement the `list_opts` method in each implementation.
- the ListOptions support offset, delimiter, max_keys, extension(maybe we can include the prefix as a option into ListOptions, but in order to keep the style from other methods, keep prefix as a alone parameter currently)
- add a list_with_composite_conditions test case by compose prefix, offset, delimiter, max_keys

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
- TBD: whether mark these methods: list, list_with_offset, list_with_delimiter as `deprecated`
