### PR TITLE
feat: Add `SpawnService` and `SpawnedReqwestConnector` for running requests on a different runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,9 @@ jobs:
       - name: Run object_store tests
         run: cargo test --features=aws,azure,gcp,http
 
+      # Don't rerun doc tests (some of them rely on features other than aws)
       - name: Run object_store tests (AWS native conditional put)
-        run: cargo test --features=aws
+        run: cargo test --lib --tests --features=aws
         env:
           AWS_CONDITIONAL_PUT: etag
           AWS_COPY_IF_NOT_EXISTS: multipart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           echo "LOCALSTACK_CONTAINER=$(docker run -d -p 4566:4566 localstack/localstack:4.0.3)" >> $GITHUB_ENV
           echo "EC2_METADATA_CONTAINER=$(docker run -d -p 1338:1338 amazon/amazon-ec2-metadata-mock:v1.9.2 --imdsv2)" >> $GITHUB_ENV
           aws --endpoint-url=http://localhost:4566 s3 mb s3://test-bucket
+          aws --endpoint-url=http://localhost:4566 s3 mb s3://test-bucket-for-spawn
           aws --endpoint-url=http://localhost:4566 s3api create-bucket --bucket test-object-lock --object-lock-enabled-for-bucket
           aws --endpoint-url=http://localhost:4566 dynamodb create-table --table-name test-table --key-schema AttributeName=path,KeyType=HASH AttributeName=etag,KeyType=RANGE --attribute-definitions AttributeName=path,AttributeType=S AttributeName=etag,AttributeType=S --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rusty-tags.vi
 .flatbuffers/
 .idea/
 .vscode
+.zed
 .devcontainer
 venv/*
 # created by doctests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ Or directly with:
 
 ```
 aws s3 mb s3://test-bucket --endpoint-url=http://localhost:4566
+aws --endpoint-url=http://localhost:4566 s3 mb s3://test-bucket-for-spawn
 aws --endpoint-url=http://localhost:4566 dynamodb create-table --table-name test-table --key-schema AttributeName=path,KeyType=HASH AttributeName=etag,KeyType=RANGE --attribute-definitions AttributeName=path,AttributeType=S AttributeName=etag,AttributeType=S --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 ```
 

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -497,6 +497,7 @@ impl MultipartStore for AmazonS3 {
 mod tests {
     use super::*;
     use crate::client::get::GetClient;
+    use crate::client::SpawnedReqwestConnector;
     use crate::integration::*;
     use crate::tests::*;
     use crate::ClientOptions;
@@ -819,5 +820,55 @@ mod tests {
 
             store.delete(location).await.unwrap();
         }
+    }
+
+    /// Integration test that ensures I/O is done on an alternate threadpool
+    /// when using the `SpawnedReqwestConnector`.
+    #[test]
+    fn s3_alternate_threadpool_spawned_request_connector() {
+        maybe_skip_integration!();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        // Runtime with I/O enabled
+        let io_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all() // <-- turns on IO
+            .build()
+            .unwrap();
+
+        // Runtime without I/O enabled
+        let non_io_runtime = tokio::runtime::Builder::new_current_thread()
+            // note: no call to enable_all
+            .build()
+            .unwrap();
+
+        // run the io runtime in a different thread
+        let io_handle = io_runtime.handle().clone();
+        let thread_handle = std::thread::spawn(move || {
+            io_runtime.block_on(async move {
+                shutdown_rx.await.unwrap();
+            });
+        });
+
+        let store = AmazonS3Builder::from_env()
+            .with_http_connector(SpawnedReqwestConnector::new(io_handle))
+            .build()
+            .unwrap();
+
+        // run a request on the non io runtime -- will fail if the connector
+        // does not spawn the request to the io runtime
+        non_io_runtime
+            .block_on(async move {
+                let path = Path::from("alternate_threadpool/test.txt");
+                store.delete(&path).await.ok(); // remove the file if it exists from prior runs
+                store.put(&path, "foo".into()).await?;
+                let res = store.get(&path).await?.bytes().await?;
+                assert_eq!(res.as_ref(), b"foo");
+                Ok(()) as Result<()>
+            })
+            .expect("failed to run request on non io runtime");
+
+        // shutdown the io runtime and thread
+        shutdown_tx.send(()).ok();
+        thread_handle.join().expect("runtime thread panicked");
     }
 }

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -863,6 +863,7 @@ mod tests {
                 store.put(&path, "foo".into()).await?;
                 let res = store.get(&path).await?.bytes().await?;
                 assert_eq!(res.as_ref(), b"foo");
+                store.delete(&path).await?; // cleanup
                 Ok(()) as Result<()>
             })
             .expect("failed to run request on non io runtime");

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -850,6 +850,8 @@ mod tests {
         });
 
         let store = AmazonS3Builder::from_env()
+            // use different bucket to avoid collisions with other tests
+            .with_bucket_name("test-bucket-for-spawn")
             .with_http_connector(SpawnedReqwestConnector::new(io_handle))
             .build()
             .unwrap();

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::connection::HttpErrorKind;
-use crate::client::{HttpClient, HttpError, HttpRequest, HttpRequestBody};
+use crate::client::{HttpClient, HttpError, HttpErrorKind, HttpRequest, HttpRequestBody};
 use http::header::{InvalidHeaderName, InvalidHeaderValue};
 use http::uri::InvalidUri;
 use http::{HeaderName, HeaderValue, Method, Uri};

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::body::{HttpRequest, HttpResponse};
 use crate::client::builder::{HttpRequestBuilder, RequestBuilderError};
-use crate::client::HttpResponseBody;
+use crate::client::{HttpRequest, HttpResponse, HttpResponseBody};
 use crate::ClientOptions;
 use async_trait::async_trait;
 use http::{Method, Uri};

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::client::builder::{HttpRequestBuilder, RequestBuilderError};
-use crate::client::http::{connection, spawn};
 use crate::client::{HttpRequest, HttpResponse, HttpResponseBody};
 use crate::ClientOptions;
 use async_trait::async_trait;

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -359,7 +359,7 @@ impl HttpConnector for SpawnedReqwestConnector {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
 pub(crate) fn http_connector(
     custom: Option<Arc<dyn HttpConnector>>,
 ) -> crate::Result<Arc<dyn HttpConnector>> {

--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Generic HTTP client abstraction
+
+mod body;
+pub use body::*;
+
+mod connection;
+pub use connection::*;
+
+mod spawn;
+pub use spawn::*;

--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -16,6 +16,20 @@
 // under the License.
 
 //! Generic HTTP client abstraction
+//!
+//! # Spawning requests on separate runtime
+//!
+//! The http client provides a http connector [`connection::SpawnedReqwestConnector`] that can wrap all requests
+//! tasks on a provided Tokio runtime handle using [`spawn::Service`].
+//!
+//! ```
+//! use tokio::runtime::Runtime;
+//! let io_runtime: Runtime = Runtime::new();
+//! let store: Arc<dyn ObjectStore> = MicrosoftAzureBuilder::new()
+//!     .with_url(url)
+//!     .with_http_connector(SpawnedReqwestConnector::new(io_runtime.handle().clone()))
+//!     .build()?;
+//! ```
 
 mod body;
 pub use body::*;

--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -15,21 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Generic HTTP client abstraction
-//!
-//! # Spawning requests on separate runtime
-//!
-//! The http client provides a http connector [`connection::SpawnedReqwestConnector`] that can wrap all requests
-//! tasks on a provided Tokio runtime handle using [`spawn::Service`].
-//!
-//! ```
-//! use tokio::runtime::Runtime;
-//! let io_runtime: Runtime = Runtime::new();
-//! let store: Arc<dyn ObjectStore> = MicrosoftAzureBuilder::new()
-//!     .with_url(url)
-//!     .with_http_connector(SpawnedReqwestConnector::new(io_runtime.handle().clone()))
-//!     .build()?;
-//! ```
+//! HTTP client abstraction
 
 mod body;
 pub use body::*;

--- a/src/client/http/spawn.rs
+++ b/src/client/http/spawn.rs
@@ -123,6 +123,7 @@ impl Body for SpawnBody {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/client/http/spawn.rs
+++ b/src/client/http/spawn.rs
@@ -41,6 +41,10 @@ impl From<SpawnError> for HttpError {
 }
 
 /// Wraps a provided [`HttpService`] and runs it on a separate tokio runtime
+///
+/// See example on [`SpawnedReqwestConnector`]
+///
+/// [`SpawnedReqwestConnector`]: crate::client::http::SpawnedReqwestConnector
 #[derive(Debug)]
 pub struct SpawnService<T: HttpService + Clone> {
     inner: T,

--- a/src/client/http/spawn.rs
+++ b/src/client/http/spawn.rs
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::client::{
+    HttpError, HttpErrorKind, HttpRequest, HttpResponse, HttpResponseBody, HttpService,
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::Response;
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use thiserror::Error;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+/// Spawn error
+#[derive(Debug, Error)]
+#[error("SpawnError")]
+struct SpawnError {}
+
+impl From<SpawnError> for HttpError {
+    fn from(value: SpawnError) -> Self {
+        Self::new(HttpErrorKind::Interrupted, value)
+    }
+}
+
+/// Wraps a provided [`HttpService`] and runs it on a separate tokio runtime
+#[derive(Debug)]
+pub struct SpawnService<T: HttpService + Clone> {
+    inner: T,
+    runtime: Handle,
+}
+
+impl<T: HttpService + Clone> SpawnService<T> {
+    /// Creates a new [`SpawnService`] from the provided
+    pub fn new(inner: T, runtime: Handle) -> Self {
+        Self { inner, runtime }
+    }
+}
+
+#[async_trait]
+impl<T: HttpService + Clone> HttpService for SpawnService<T> {
+    async fn call(&self, req: HttpRequest) -> Result<HttpResponse, HttpError> {
+        let inner = self.inner.clone();
+        let (send, recv) = tokio::sync::oneshot::channel();
+
+        // We use an unbounded channel to prevent backpressure across the runtime boundary
+        // which could in turn starve the underlying IO operations
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        let handle = SpawnHandle(self.runtime.spawn(async move {
+            let r = match HttpService::call(&inner, req).await {
+                Ok(resp) => resp,
+                Err(e) => {
+                    let _ = send.send(Err(e));
+                    return;
+                }
+            };
+
+            let (parts, mut body) = r.into_parts();
+            if send.send(Ok(parts)).is_err() {
+                return;
+            }
+
+            while let Some(x) = body.frame().await {
+                sender.send(x).unwrap();
+            }
+        }));
+
+        let parts = recv.await.map_err(|_| SpawnError {})??;
+
+        Ok(Response::from_parts(
+            parts,
+            HttpResponseBody::new(SpawnBody {
+                stream: receiver,
+                _worker: handle,
+            }),
+        ))
+    }
+}
+
+/// A wrapper around a [`JoinHandle`] that aborts on drop
+struct SpawnHandle(JoinHandle<()>);
+impl Drop for SpawnHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+type StreamItem = Result<Frame<Bytes>, HttpError>;
+
+struct SpawnBody {
+    stream: tokio::sync::mpsc::UnboundedReceiver<StreamItem>,
+    _worker: SpawnHandle,
+}
+
+impl Body for SpawnBody {
+    type Data = Bytes;
+    type Error = HttpError;
+
+    fn poll_frame(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<StreamItem>> {
+        self.stream.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::mock_server::MockServer;
+    use crate::client::retry::RetryExt;
+    use crate::client::HttpClient;
+    use crate::RetryConfig;
+
+    async fn test_client(client: HttpClient) {
+        let (send, recv) = tokio::sync::oneshot::channel();
+
+        let mock = MockServer::new().await;
+        mock.push(Response::new("BANANAS".to_string()));
+
+        let url = mock.url().to_string();
+        let thread = std::thread::spawn(|| {
+            futures::executor::block_on(async move {
+                let retry = RetryConfig::default();
+                let ret = client.get(url).send_retry(&retry).await.unwrap();
+                let payload = ret.into_body().bytes().await.unwrap();
+                assert_eq!(payload.as_ref(), b"BANANAS");
+                let _ = send.send(());
+            })
+        });
+        recv.await.unwrap();
+        thread.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_spawn() {
+        let client = HttpClient::new(SpawnService::new(reqwest::Client::new(), Handle::current()));
+        test_client(client).await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_no_spawn() {
+        let client = HttpClient::new(reqwest::Client::new());
+        test_client(client).await;
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Generic utilities reqwest based ObjectStore implementations
+//! Generic utilities for [`reqwest`] based [`ObjectStore`] implementations
+//!
+//! [`ObjectStore`]: crate::ObjectStore
 
 pub(crate) mod backoff;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,19 +43,12 @@ pub(crate) mod header;
 #[cfg(any(feature = "aws", feature = "gcp"))]
 pub(crate) mod s3;
 
-mod body;
-pub use body::{HttpRequest, HttpRequestBody, HttpResponse, HttpResponseBody};
-
 pub(crate) mod builder;
-
-mod connection;
-pub(crate) use connection::http_connector;
-#[cfg(not(target_arch = "wasm32"))]
-pub use connection::ReqwestConnector;
-pub use connection::{HttpClient, HttpConnector, HttpError, HttpErrorKind, HttpService};
+mod http;
 
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub(crate) mod parts;
+pub use http::*;
 
 use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -127,7 +120,7 @@ pub enum ClientConfigKey {
     ProxyExcludes,
     /// Randomize order addresses that the DNS resolution yields.
     ///
-    /// This will spread the connections accross more servers.
+    /// This will spread the connections across more servers.
     RandomizeAddresses,
     /// Request timeout
     ///

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -19,8 +19,7 @@
 
 use crate::client::backoff::{Backoff, BackoffConfig};
 use crate::client::builder::HttpRequestBuilder;
-use crate::client::connection::HttpErrorKind;
-use crate::client::{HttpClient, HttpError, HttpRequest, HttpResponse};
+use crate::client::{HttpClient, HttpError, HttpErrorKind, HttpRequest, HttpResponse};
 use crate::PutPayload;
 use futures::future::BoxFuture;
 use http::{Method, Uri};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,10 +497,10 @@
 //! [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs/
 //! [`webpki-roots`]: https://crates.io/crates/webpki-roots
 //!
-//! # Customized HTTP Clients
+//! # Customizing HTTP Clients
 //!
-//! Many `ObjectStore` implementations permit customization of the HTTP client via
-//! the [`HttpConnector`] trait and utilities in the  [`client`] module.
+//! Many [`ObjectStore`] implementations permit customization of the HTTP client via
+//! the [`HttpConnector`] trait and utilities in the [`client`] module.
 //! Examples include injecting custom HTTP headers or using an alternate
 //! tokio Runtime I/O requests.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,19 @@
 //! [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs/
 //! [`webpki-roots`]: https://crates.io/crates/webpki-roots
 //!
+//! # Tokio runtime separation
+//!
+//! Spawn requests on a different runtime that solely does IO using the [`client::SpawnedReqwestConnector`].
+//! This can be used in situations where the existing Tokio runtime is used to spawn cpu-bound heavy tasks.
+//!
+//! ```
+//! use tokio::runtime::Runtime;
+//! let io_runtime: Runtime = Runtime::new();
+//! let store: Arc<dyn ObjectStore> = MicrosoftAzureBuilder::new()
+//!     .with_url(url)
+//!     .with_http_connector(SpawnedReqwestConnector::new(io_runtime.handle().clone()))
+//!     .build()?;
+//! ```
 
 #[cfg(feature = "aws")]
 pub mod aws;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,19 +497,14 @@
 //! [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs/
 //! [`webpki-roots`]: https://crates.io/crates/webpki-roots
 //!
-//! # Tokio runtime separation
+//! # Customized HTTP Clients
 //!
-//! Spawn requests on a different runtime that solely does IO using the [`client::SpawnedReqwestConnector`].
-//! This can be used in situations where the existing Tokio runtime is used to spawn cpu-bound heavy tasks.
+//! Many `ObjectStore` implementations permit customization of the HTTP client via
+//! the [`HttpConnector`] trait and utilities in the  [`client`] module.
+//! Examples include injecting custom HTTP headers or using an alternate
+//! tokio Runtime I/O requests.
 //!
-//! ```
-//! use tokio::runtime::Runtime;
-//! let io_runtime: Runtime = Runtime::new();
-//! let store: Arc<dyn ObjectStore> = MicrosoftAzureBuilder::new()
-//!     .with_url(url)
-//!     .with_http_connector(SpawnedReqwestConnector::new(io_runtime.handle().clone()))
-//!     .build()?;
-//! ```
+//! [`HttpConnector`]: client::HttpConnector
 
 #[cfg(feature = "aws")]
 pub mod aws;


### PR DESCRIPTION
# Which issue does this PR close?
- closes https://github.com/apache/arrow-rs-object-store/issues/13

Adds support for spawning reqwuests tasks to another Runtime. Credits to @tustvold, I simply added an additional connector in there to make it easier for others to integrate this in their code base.

- Port of https://github.com/apache/arrow-rs/pull/7253

Example:

```rust

  let prefix = Path::parse(path)?;
  let mut builder = MicrosoftAzureBuilder::new().with_url(url.to_string());
  for (key, value) in config.iter() {
      builder = builder.with_config(*key, value.clone());
  }
  let inner = builder
      .with_retry(self.parse_retry_config(options)?)
      .with_http_connector(SpawnedReqwestConnector::new(io_handle))
      .build()?;
```

# Rationale for this change
Allows a separation of cpu bound tasks and io bound tasks

# What changes are included in this PR?
- Adds a SpawnService
- Adds a SpawnedReqwestConnector

# Are there any user-facing changes?
Only an additional http_connector.

cc @alamb 😃 