### PR TITLE
feat: add EKS Pod Identity support (#282)

### DIFF
--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -719,6 +719,64 @@ async fn task_credential(
     })
 }
 
+/// EKS Pod Identity credential provider.
+///
+/// Uses the endpoint in `AWS_CONTAINER_CREDENTIALS_FULL_URI`
+/// and the bearer token in `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`
+/// to fetch ephemeral AWS credentials from an EKS pod.
+#[derive(Debug)]
+pub(crate) struct EKSPodCredentialProvider {
+    pub url: String,
+    pub token_file: String,
+    pub retry: RetryConfig,
+    pub client: HttpClient,
+    pub cache: TokenCache<Arc<AwsCredential>>,
+}
+
+#[async_trait]
+impl CredentialProvider for EKSPodCredentialProvider {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> Result<Arc<AwsCredential>> {
+        self.cache
+            .get_or_insert_with(|| {
+                eks_credential(&self.client, &self.retry, &self.url, &self.token_file)
+            })
+            .await
+            .map_err(|source| crate::Error::Generic {
+                store: STORE,
+                source,
+            })
+    }
+}
+
+/// Performs the actual credential retrieval and parsing for `EKSPodCredentialProvider`.
+///
+/// <https://mozillazg.com/2023/12/security-deep-dive-into-aws-eks-pod-identity-feature-en.html>
+async fn eks_credential(
+    client: &HttpClient,
+    retry: &RetryConfig,
+    url: &str,
+    token_file: &str,
+) -> Result<TemporaryToken<Arc<AwsCredential>>, StdError> {
+    let token = std::fs::read_to_string(token_file)
+        .map_err(|e| format!("Failed to read EKS token file '{token_file}': {e}"))?;
+
+    let mut req = client.request(Method::GET, url);
+    req = req.header("Authorization", token);
+
+    // The JSON from the EKS credential endpoint has the same shape as ECS task credentials
+    let creds: InstanceCredentials = req.send_retry(retry).await?.into_body().json().await?;
+
+    let now = Utc::now();
+    let ttl = (creds.expiration - now).to_std().unwrap_or_default();
+
+    Ok(TemporaryToken {
+        token: Arc::new(creds.into()),
+        expiry: Some(Instant::now() + ttl),
+    })
+}
+
 /// A session provider as used by S3 Express One Zone
 ///
 /// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html>
@@ -773,6 +831,7 @@ struct CreateSessionOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::aws::{AmazonS3Builder, AmazonS3ConfigKey};
     use crate::client::mock_server::MockServer;
     use crate::client::HttpClient;
     use http::Response;
@@ -1155,5 +1214,46 @@ mod tests {
         instance_creds(&client, &retry_config, endpoint, false)
             .await
             .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_eks_pod_credential_provider() {
+        use crate::client::mock_server::MockServer;
+        use http::Response;
+        use std::fs::File;
+        use std::io::Write;
+
+        let mock_server = MockServer::new().await;
+
+        mock_server.push(Response::new(
+            r#"{
+            "AccessKeyId": "TEST_KEY",
+            "SecretAccessKey": "TEST_SECRET",
+            "Token": "TEST_SESSION_TOKEN",
+            "Expiration": "2100-01-01T00:00:00Z"
+        }"#
+            .to_string(),
+        ));
+
+        let token_file = tempfile::NamedTempFile::new().expect("cannot create temp file");
+        let path = token_file.path().to_string_lossy().into_owned();
+        let mut f = File::create(token_file.path()).unwrap();
+        write!(f, "TEST_BEARER_TOKEN").unwrap();
+
+        let builder = AmazonS3Builder::new()
+            .with_bucket_name("some-bucket")
+            .with_config(
+                AmazonS3ConfigKey::ContainerCredentialsFullUri,
+                mock_server.url(),
+            )
+            .with_config(AmazonS3ConfigKey::ContainerAuthorizationTokenFile, &path);
+
+        let s3 = builder.build().unwrap();
+
+        let cred = s3.client.config.credentials.get_credential().await.unwrap();
+
+        assert_eq!(cred.key_id, "TEST_KEY");
+        assert_eq!(cred.secret_key, "TEST_SECRET");
+        assert_eq!(cred.token.as_deref(), Some("TEST_SESSION_TOKEN"));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #282 

# Rationale for this change
 
This PR extends the `AmazonS3Builder` so that it recognises and supports EKS Pod Identity credentials using the two environment variables:

- `AWS_CONTAINER_CREDENTIALS_FULL_URI`

- `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`

Previously, the builder only considered ECS task credentials (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`), instance metadata, static credentials, or web identity tokens. Adding EKS Pod Identity support aligns it with modern Kubernetes IRSA setups, allowing pods to retrieve AWS credentials from an EKS endpoint without needing to mount AWS credentials directly.

# What changes are included in this PR?

1. **New Config Keys**
Adds `AmazonS3ConfigKey::ContainerCredentialsFullUri` and `AmazonS3ConfigKey::ContainerAuthorizationTokenFile` to the config-based approach, for parsing EKS Pod Identity settings. The builder picks these keys from environment variables `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`.

2. **EKSPodCredentialProvider**
Introduces an `EKSPodCredentialProvider`, which is constructed when both config keys are set. It uses a bearer token (read from the specified file) to fetch short-lived credentials from the EKS credential endpoint.

3. **Builder Logic**
Adjusts `AmazonS3Builder::build` to give priority to EKS credentials if both the full URI and token file are specified. It checks environment variables in `from_env` or direct calls to `with_config`, falling back to ECS or instance metadata if EKS variables are absent.

4. **Tests**
Adds tests to confirm EKS credentials build and provider.

# Are there any user-facing changes?

- **New EKS Credential Support**
Users in EKS can now set `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, and the builder automatically fetches credentials.

- **Configuration Keys**
Two new config keys are recognised by the builder:

  - `AmazonS3ConfigKey::ContainerCredentialsFullUri`
  - `AmazonS3ConfigKey::ContainerAuthorizationTokenFile`

These changes are backwards-compatible: existing ECS, static credentials, or IMDS-based setups continue to work unchanged. No additional user steps are required unless they specifically opt to use EKS Pod Identity.
