### PR TITLE
[WIP] implement multi range query in single request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"] }
+mpart-async = "0.7.0"
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.29.0", features = ["fs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ integration = ["rand"]
 [dev-dependencies] # In alphabetical order
 hyper = { version = "1.2", features = ["server"] }
 hyper-util = "0.1"
+mockito = "1.7"
 rand = "0.9"
 tempfile = "3.1.0"
 regex = "1.11.1"

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -851,6 +851,16 @@ impl GetClient for S3Client {
             false => Method::GET,
         };
 
+        match options.range.as_ref() {
+            Some(inner) if inner.as_single().is_none() => {
+                // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax
+                return Err(crate::Error::NotSupported {
+                    source: "AWS does not support multiple range requests".into(),
+                });
+            }
+            _ => {}
+        }
+
         let mut builder = self.client.request(method, url);
         if self
             .config

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -35,6 +35,7 @@ use crate::client::s3::{
 use crate::client::{GetOptionsExt, HttpClient, HttpError, HttpResponse};
 use crate::multipart::PartId;
 use crate::path::DELIMITER;
+use crate::util::RangeValue;
 use crate::{
     Attribute, Attributes, ClientOptions, GetOptions, ListResult, MultipartId, Path,
     PutMultipartOpts, PutPayload, PutResult, Result, RetryConfig, TagSet,
@@ -838,7 +839,11 @@ impl GetClient for S3Client {
     };
 
     /// Make an S3 GET request <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>
-    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<HttpResponse> {
+    async fn get_request<R: RangeValue>(
+        &self,
+        path: &Path,
+        options: GetOptions<R>,
+    ) -> Result<HttpResponse> {
         let credential = self.config.get_session_credential().await?;
         let url = self.config.path_url(path);
         let method = match options.head {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -500,6 +500,7 @@ mod tests {
     use crate::integration::*;
     use crate::tests::*;
     use crate::ClientOptions;
+    use crate::GetRange;
     use base64::prelude::BASE64_STANDARD;
     use base64::Engine;
     use http::HeaderMap;
@@ -743,7 +744,7 @@ mod tests {
         for location in &locations {
             let res = store
                 .client
-                .get_request(location, GetOptions::default())
+                .get_request::<GetRange>(location, GetOptions::default())
                 .await
                 .unwrap();
             let headers = res.headers();
@@ -799,7 +800,7 @@ mod tests {
         for location in &locations {
             let res = store
                 .client
-                .get_request(location, GetOptions::default())
+                .get_request::<GetRange>(location, GetOptions::default())
                 .await
                 .unwrap();
             let headers = res.headers();

--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -83,7 +83,7 @@ impl<T: GetClient> GetClientExt for T {
     ) -> Result<Vec<Bytes>> {
         let range = options.range.clone();
         if let Some(ranges) = range.as_ref() {
-            for r in ranges.as_ref().iter() {
+            for r in ranges.as_ref() {
                 r.is_valid().map_err(|e| crate::Error::Generic {
                     store: T::STORE,
                     source: Box::new(e),

--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -20,7 +20,7 @@ use std::ops::Range;
 use crate::client::header::{header_meta, HeaderConfig};
 use crate::client::HttpResponse;
 use crate::path::Path;
-use crate::util::GetManyRanges;
+use crate::util::{GetManyRanges, RangeValue};
 use crate::{Attribute, Attributes, GetOptions, GetRange, GetResult, GetResultPayload, Result};
 use async_trait::async_trait;
 use bytes::{Buf, Bytes, BytesMut};
@@ -40,7 +40,7 @@ pub(crate) trait GetClient: Send + Sync + 'static {
     /// Configure the [`HeaderConfig`] for this client
     const HEADER_CONFIG: HeaderConfig;
 
-    async fn get_request<R: Send + ToString>(
+    async fn get_request<R: RangeValue>(
         &self,
         path: &Path,
         options: GetOptions<R>,
@@ -301,7 +301,7 @@ fn get_result<T: GetClient>(
 }
 
 async fn get_manyranges<T: GetClient>(
-    location: &Path,
+    _location: &Path,
     ranges: GetManyRanges,
     response: HttpResponse,
 ) -> Result<Vec<bytes::Bytes>, GetResultError> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -629,6 +629,12 @@ impl ClientOptions {
         }
     }
 
+    /// Returns wether or not the client is configured to support multiple querying multiple ranges
+    /// in a single request
+    pub(crate) fn supports_multiple_ranges(&self) -> bool {
+        self.http_multiple_ranges.get().unwrap_or(false)
+    }
+
     /// Returns a copy of this [`ClientOptions`] with overrides necessary for metadata endpoint access
     ///
     /// In particular:
@@ -754,12 +760,15 @@ impl ClientOptions {
     }
 }
 
-pub(crate) trait GetOptionsExt {
-    fn with_get_options(self, options: GetOptions) -> Self;
+pub(crate) trait GetOptionsExt<R>
+where
+    R: ToString,
+{
+    fn with_get_options(self, options: GetOptions<R>) -> Self;
 }
 
-impl GetOptionsExt for HttpRequestBuilder {
-    fn with_get_options(mut self, options: GetOptions) -> Self {
+impl<R: ToString> GetOptionsExt<R> for HttpRequestBuilder {
+    fn with_get_options(mut self, options: GetOptions<R>) -> Self {
         use hyper::header::*;
 
         let GetOptions {

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -29,7 +29,7 @@ use crate::gcp::credential::CredentialExt;
 use crate::gcp::{GcpCredential, GcpCredentialProvider, GcpSigningCredentialProvider, STORE};
 use crate::multipart::PartId;
 use crate::path::{Path, DELIMITER};
-use crate::util::hex_encode;
+use crate::util::{hex_encode, RangeValue};
 use crate::{
     Attribute, Attributes, ClientOptions, GetOptions, ListResult, MultipartId, PutMode,
     PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, RetryConfig,
@@ -617,7 +617,11 @@ impl GetClient for GoogleCloudStorageClient {
     };
 
     /// Perform a get request <https://cloud.google.com/storage/docs/xml-api/get-object-download>
-    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<HttpResponse> {
+    async fn get_request<R: RangeValue>(
+        &self,
+        path: &Path,
+        options: GetOptions<R>,
+    ) -> Result<HttpResponse> {
         let credential = self.get_credential().await?;
         let url = self.object_url(path);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -915,7 +915,7 @@ pub struct ObjectMeta {
 
 /// Options for a get request, such as range
 #[derive(Debug, Default, Clone)]
-pub struct GetOptions {
+pub struct GetOptions<Range = GetRange> {
     /// Request will succeed if the `ObjectMeta::e_tag` matches
     /// otherwise returning [`Error::Precondition`]
     ///
@@ -958,7 +958,7 @@ pub struct GetOptions {
     /// otherwise returning [`Error::NotModified`]
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc9110#name-range>
-    pub range: Option<GetRange>,
+    pub range: Option<Range>,
     /// Request a particular object version
     pub version: Option<String>,
     /// Request transfer of no content

--- a/src/util.rs
+++ b/src/util.rs
@@ -179,14 +179,14 @@ pub(crate) trait RangeValue: Send + Sized + ToString {
 
 impl RangeValue for GetRange {
     fn as_single(&self) -> Option<&GetRange> {
-        Some(&self)
+        Some(self)
     }
 }
 
 impl RangeValue for GetManyRanges {
     fn as_single(&self) -> Option<&GetRange> {
         if self.0.len() == 1 {
-            self.0.get(0)
+            self.0.first()
         } else {
             None
         }
@@ -198,7 +198,7 @@ pub(crate) struct GetManyRanges(Vec<GetRange>);
 
 impl From<&[Range<u64>]> for GetManyRanges {
     fn from(ranges: &[Range<u64>]) -> Self {
-        Self(ranges.into_iter().cloned().map(GetRange::from).collect())
+        Self(ranges.iter().cloned().map(GetRange::from).collect())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -173,6 +173,26 @@ fn merge_ranges(ranges: &[Range<u64>], coalesce: u64) -> Vec<Range<u64>> {
     ret
 }
 
+pub(crate) trait RangeValue: Send + Sized + ToString {
+    fn as_single(&self) -> Option<&GetRange>;
+}
+
+impl RangeValue for GetRange {
+    fn as_single(&self) -> Option<&GetRange> {
+        Some(&self)
+    }
+}
+
+impl RangeValue for GetManyRanges {
+    fn as_single(&self) -> Option<&GetRange> {
+        if self.0.len() == 1 {
+            self.0.get(0)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub(crate) struct GetManyRanges(Vec<GetRange>);
 
@@ -318,7 +338,7 @@ impl GetRange {
         match self {
             Self::Bounded(r) => write!(f, "{}-{}", r.start, r.end - 1),
             Self::Offset(o) => write!(f, "{o}-"),
-            Self::Suffix(n) => write!(f, "{n}"),
+            Self::Suffix(n) => write!(f, "-{n}"),
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Right now, when requesting multiple ranges for a file, multiple queries are fired (if the gap between the ranges > `OBJECT_STORE_COALESCE_DEFAULT`). This could be avoided by using the [multi ranges capability](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests#multipart_ranges) when doing fetching ranges through HTTP.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR introduces a new `get_manyranges` method to extract the multipart version of the response.
It also updates the `GetOptions` to add an type parameter so that `Range` can be `GetRange` or `GetManyRanges`.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

`GetOptions` now has a parameter `Range` but has `GetRange` as a default type which should be transparent for the users.

<!---
If there are any breaking changes to public APIs, please call them out.
-->
