### PR TITLE
Prepare for 0.12.1 release

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -23,5 +23,5 @@ add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["
 # so that the component is shown associated with the issue
 issue-line-labels=object-store
 # skip non object_store issues
-exclude-labels=development-process,invalid,arrow,parquet,arrow-flight,parquet-derive,question
+exclude-labels=development-process,invalid
 breaking_labels=api-change

--- a/CHANGELOG-old.md
+++ b/CHANGELOG-old.md
@@ -19,6 +19,56 @@
 
 # Historical Changelog
 
+## [object_store_0.12.0](https://github.com/apache/arrow-rs/tree/object_store_0.12.0) (2025-03-05)
+
+[Full Changelog](https://github.com/apache/arrow-rs/compare/object_store_0.11.2...object_store_0.12.0)
+
+**Breaking changes:**
+
+- feat: add `Extensions` to object store `PutMultipartOpts` [\#7214](https://github.com/apache/arrow-rs/pull/7214) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
+- feat: add `Extensions` to object store `PutOptions` [\#7213](https://github.com/apache/arrow-rs/pull/7213) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
+- chore: enable conditional put by default for S3 [\#7181](https://github.com/apache/arrow-rs/pull/7181) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([meteorgan](https://github.com/meteorgan))
+- feat: add `Extensions` to object store `GetOptions` [\#7170](https://github.com/apache/arrow-rs/pull/7170) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
+- feat\(object\_store\): Override DNS Resolution to Randomize IP Selection [\#7123](https://github.com/apache/arrow-rs/pull/7123) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
+- Use `u64` range instead of `usize`, for better wasm32 support [\#6961](https://github.com/apache/arrow-rs/pull/6961) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([XiangpengHao](https://github.com/XiangpengHao))
+- object\_store: Add enabled-by-default "fs" feature [\#6636](https://github.com/apache/arrow-rs/pull/6636) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([Turbo87](https://github.com/Turbo87))
+- Return `BoxStream` with `'static` lifetime from `ObjectStore::list` [\#6619](https://github.com/apache/arrow-rs/pull/6619) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
+- object\_store: Migrate from snafu to thiserror [\#6266](https://github.com/apache/arrow-rs/pull/6266) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([Turbo87](https://github.com/Turbo87))
+
+**Implemented enhancements:**
+
+- Object Store: S3 IP address selection is biased [\#7117](https://github.com/apache/arrow-rs/issues/7117) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- object\_store: GCSObjectStore should derive Clone [\#7113](https://github.com/apache/arrow-rs/issues/7113) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- Remove all RCs after release [\#7059](https://github.com/apache/arrow-rs/issues/7059) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- LocalFileSystem::list\_with\_offset is very slow over network file system [\#7018](https://github.com/apache/arrow-rs/issues/7018) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- Release object store `0.11.2` \(non API breaking\) Around Dec 15 2024 [\#6902](https://github.com/apache/arrow-rs/issues/6902) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+
+**Fixed bugs:**
+
+- LocalFileSystem errors with satisfiable range request [\#6749](https://github.com/apache/arrow-rs/issues/6749) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+
+**Merged pull requests:**
+
+- ObjectStore WASM32 Support [\#7226](https://github.com/apache/arrow-rs/pull/7226) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
+- \[main\] Bump arrow version to 54.2.1 \(\#7207\) [\#7212](https://github.com/apache/arrow-rs/pull/7212) ([alamb](https://github.com/alamb))
+- Decouple ObjectStore from Reqwest [\#7183](https://github.com/apache/arrow-rs/pull/7183) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
+- object\_store: Disable all compression formats in HTTP reqwest client [\#7143](https://github.com/apache/arrow-rs/pull/7143) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylewlacy](https://github.com/kylewlacy))
+- refactor: remove unused `async` from `InMemory::entry` [\#7133](https://github.com/apache/arrow-rs/pull/7133) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
+- object\_store/gcp: derive Clone for GoogleCloudStorage [\#7112](https://github.com/apache/arrow-rs/pull/7112) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([james-rms](https://github.com/james-rms))
+- Update version to 54.2.0 and add CHANGELOG [\#7110](https://github.com/apache/arrow-rs/pull/7110) ([alamb](https://github.com/alamb))
+- Remove all RCs after release [\#7060](https://github.com/apache/arrow-rs/pull/7060) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kou](https://github.com/kou))
+- Update release schedule README.md [\#7053](https://github.com/apache/arrow-rs/pull/7053) ([alamb](https://github.com/alamb))
+- Create GitHub releases automatically on tagging [\#7042](https://github.com/apache/arrow-rs/pull/7042) ([kou](https://github.com/kou))
+- Change Log On Succesful S3 Copy / Multipart Upload to Debug [\#7033](https://github.com/apache/arrow-rs/pull/7033) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([diptanu](https://github.com/diptanu))
+- Prepare for `54.1.0` release [\#7031](https://github.com/apache/arrow-rs/pull/7031) ([alamb](https://github.com/alamb))
+- Add a custom implementation `LocalFileSystem::list_with_offset`  [\#7019](https://github.com/apache/arrow-rs/pull/7019) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([corwinjoy](https://github.com/corwinjoy))
+- Improve docs for `AmazonS3Builder::from_env` [\#6977](https://github.com/apache/arrow-rs/pull/6977) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
+- Fix WASM CI for Rust 1.84 release [\#6963](https://github.com/apache/arrow-rs/pull/6963) ([alamb](https://github.com/alamb))
+- Update itertools requirement from 0.13.0 to 0.14.0 in /object\_store [\#6925](https://github.com/apache/arrow-rs/pull/6925) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fix LocalFileSystem with range request that ends beyond end of file [\#6751](https://github.com/apache/arrow-rs/pull/6751) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
+
+
+
 ## [object_store_0.11.2](https://github.com/apache/arrow-rs/tree/object_store_0.11.2) (2024-12-20)
 
 [Full Changelog](https://github.com/apache/arrow-rs/compare/object_store_0.11.1...object_store_0.11.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,7 @@
 - \[object\_store\] Run requests on a different tokio runtime [\#13](https://github.com/apache/arrow-rs-object-store/issues/13)
 - \[object\_store\] consider migrating `humantime` to `jiff` [\#292](https://github.com/apache/arrow-rs-object-store/issues/292)
 - Support EKS Pod Identity \(alternative to IRSA\) [\#282](https://github.com/apache/arrow-rs-object-store/issues/282)
-- Release object\_store `0.12.0` \(API breaking\) Around Feb 30 2025 [\#28](https://github.com/apache/arrow-rs-object-store/issues/28)
 - Object\_store: Create an upload method that handles concurrency [\#279](https://github.com/apache/arrow-rs-object-store/issues/279)
-- Discuss: Release object store `0.12.0` \(breaking\) or `0.11.2` \(non breaking API\) around Dec 15, 2024 [\#306](https://github.com/apache/arrow-rs-object-store/issues/306)
 - object\_store: Retry on connection duration timeouts \(retry / recover after partially reading a streaming response\) [\#53](https://github.com/apache/arrow-rs-object-store/issues/53)
 - \[object-store\] re-export `hyper` [\#293](https://github.com/apache/arrow-rs-object-store/issues/293)
 - object\_store: abort\_multipart\(\) should return NotFound error if not found [\#146](https://github.com/apache/arrow-rs-object-store/issues/146)
@@ -51,7 +49,6 @@
 - Some Inconsistencies in the Path and List [\#327](https://github.com/apache/arrow-rs-object-store/issues/327)
 - Add allow-list to restrict access to local files with LocalFileSystem [\#312](https://github.com/apache/arrow-rs-object-store/issues/312)
 - Query on usage of experimental package ring [\#310](https://github.com/apache/arrow-rs-object-store/issues/310)
-- \[EPIC\] Port object\_store content from arrow-rs repository [\#2](https://github.com/apache/arrow-rs-object-store/issues/2)
 - \[Object Store\] Make the service account used when interacting with the metadata url more flexible [\#265](https://github.com/apache/arrow-rs-object-store/issues/265)
 
 **Merged pull requests:**
@@ -67,15 +64,10 @@
 - Fix semantic versioning link in README.md [\#317](https://github.com/apache/arrow-rs-object-store/pull/317) ([lewiszlw](https://github.com/lewiszlw))
 - feat: make some helpers/utils public [\#316](https://github.com/apache/arrow-rs-object-store/pull/316) ([crepererum](https://github.com/crepererum))
 - chore: fix `integration` feature [\#314](https://github.com/apache/arrow-rs-object-store/pull/314) ([crepererum](https://github.com/crepererum))
-- Minor: Update release calendar [\#308](https://github.com/apache/arrow-rs-object-store/pull/308) ([alamb](https://github.com/alamb))
-- Update dependabot config after repo move [\#305](https://github.com/apache/arrow-rs-object-store/pull/305) ([mbrobbel](https://github.com/mbrobbel))
-- Update repo link in Cargo.toml [\#304](https://github.com/apache/arrow-rs-object-store/pull/304) ([mbrobbel](https://github.com/mbrobbel))
 - Bump `rand` to 0.9 [\#303](https://github.com/apache/arrow-rs-object-store/pull/303) ([mbrobbel](https://github.com/mbrobbel))
 - Add content length to PUT GCP multipart complete [\#257](https://github.com/apache/arrow-rs-object-store/pull/257) ([jkosh44](https://github.com/jkosh44))
 - Update README.md and Contributing guidelines [\#8](https://github.com/apache/arrow-rs-object-store/pull/8) ([alamb](https://github.com/alamb))
 - Tweaks: homepage and fix RAT [\#7](https://github.com/apache/arrow-rs-object-store/pull/7) ([alamb](https://github.com/alamb))
-- Fix CI jobs [\#6](https://github.com/apache/arrow-rs-object-store/pull/6) ([alamb](https://github.com/alamb))
-- Port `.github` templates and checks to arrow-rs-object-store crate [\#4](https://github.com/apache/arrow-rs-object-store/pull/4) ([alamb](https://github.com/alamb))
 - Import `object_store`, with history, from arrow-rs [\#3](https://github.com/apache/arrow-rs-object-store/pull/3) ([alamb](https://github.com/alamb))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,53 +19,64 @@
 
 # Changelog
 
-## [object_store_0.12.0](https://github.com/apache/arrow-rs/tree/object_store_0.12.0) (2025-03-05)
+## [v0.12.1](https://github.com/apache/arrow-rs-object-store/tree/v0.12.1) (2025-05-08)
 
-[Full Changelog](https://github.com/apache/arrow-rs/compare/object_store_0.11.2...object_store_0.12.0)
-
-**Breaking changes:**
-
-- feat: add `Extensions` to object store `PutMultipartOpts` [\#7214](https://github.com/apache/arrow-rs/pull/7214) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
-- feat: add `Extensions` to object store `PutOptions` [\#7213](https://github.com/apache/arrow-rs/pull/7213) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
-- chore: enable conditional put by default for S3 [\#7181](https://github.com/apache/arrow-rs/pull/7181) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([meteorgan](https://github.com/meteorgan))
-- feat: add `Extensions` to object store `GetOptions` [\#7170](https://github.com/apache/arrow-rs/pull/7170) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
-- feat\(object\_store\): Override DNS Resolution to Randomize IP Selection [\#7123](https://github.com/apache/arrow-rs/pull/7123) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
-- Use `u64` range instead of `usize`, for better wasm32 support [\#6961](https://github.com/apache/arrow-rs/pull/6961) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([XiangpengHao](https://github.com/XiangpengHao))
-- object\_store: Add enabled-by-default "fs" feature [\#6636](https://github.com/apache/arrow-rs/pull/6636) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([Turbo87](https://github.com/Turbo87))
-- Return `BoxStream` with `'static` lifetime from `ObjectStore::list` [\#6619](https://github.com/apache/arrow-rs/pull/6619) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
-- object\_store: Migrate from snafu to thiserror [\#6266](https://github.com/apache/arrow-rs/pull/6266) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([Turbo87](https://github.com/Turbo87))
+[Full Changelog](https://github.com/apache/arrow-rs-object-store/compare/v0.12.0...v0.12.1)
 
 **Implemented enhancements:**
 
-- Object Store: S3 IP address selection is biased [\#7117](https://github.com/apache/arrow-rs/issues/7117) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
-- object\_store: GCSObjectStore should derive Clone [\#7113](https://github.com/apache/arrow-rs/issues/7113) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
-- Remove all RCs after release [\#7059](https://github.com/apache/arrow-rs/issues/7059) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
-- LocalFileSystem::list\_with\_offset is very slow over network file system [\#7018](https://github.com/apache/arrow-rs/issues/7018) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
-- Release object store `0.11.2` \(non API breaking\) Around Dec 15 2024 [\#6902](https://github.com/apache/arrow-rs/issues/6902) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- Support Alibaba OSS Object Storage [\#323](https://github.com/apache/arrow-rs-object-store/issues/323)
+- Enable anonymous access to GCS buckets [\#302](https://github.com/apache/arrow-rs-object-store/issues/302)
+- \[object\_store\] Run requests on a different tokio runtime [\#13](https://github.com/apache/arrow-rs-object-store/issues/13)
+- \[object\_store\] consider migrating `humantime` to `jiff` [\#292](https://github.com/apache/arrow-rs-object-store/issues/292)
+- Support EKS Pod Identity \(alternative to IRSA\) [\#282](https://github.com/apache/arrow-rs-object-store/issues/282)
+- Release object\_store `0.12.0` \(API breaking\) Around Feb 30 2025 [\#28](https://github.com/apache/arrow-rs-object-store/issues/28)
+- Object\_store: Create an upload method that handles concurrency [\#279](https://github.com/apache/arrow-rs-object-store/issues/279)
+- Discuss: Release object store `0.12.0` \(breaking\) or `0.11.2` \(non breaking API\) around Dec 15, 2024 [\#306](https://github.com/apache/arrow-rs-object-store/issues/306)
+- object\_store: Retry on connection duration timeouts \(retry / recover after partially reading a streaming response\) [\#53](https://github.com/apache/arrow-rs-object-store/issues/53)
+- \[object-store\] re-export `hyper` [\#293](https://github.com/apache/arrow-rs-object-store/issues/293)
+- object\_store: abort\_multipart\(\) should return NotFound error if not found [\#146](https://github.com/apache/arrow-rs-object-store/issues/146)
+- Make `GetOptionsExt` publicly usable [\#261](https://github.com/apache/arrow-rs-object-store/issues/261)
 
 **Fixed bugs:**
 
-- LocalFileSystem errors with satisfiable range request [\#6749](https://github.com/apache/arrow-rs/issues/6749) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)]
+- Incorrect token sent as part of url signing function. [\#337](https://github.com/apache/arrow-rs-object-store/issues/337)
+- Azure Gen2 broken on latest [\#320](https://github.com/apache/arrow-rs-object-store/issues/320)
+- object\_store: Azure brokenness on 0.12.0 [\#326](https://github.com/apache/arrow-rs-object-store/issues/326)
+- Generic S3 error: Client error with status 411 Length Required [\#278](https://github.com/apache/arrow-rs-object-store/issues/278)
+
+**Closed issues:**
+
+- CI doesn't run on PRs [\#335](https://github.com/apache/arrow-rs-object-store/issues/335)
+- Some Inconsistencies in the Path and List [\#327](https://github.com/apache/arrow-rs-object-store/issues/327)
+- Add allow-list to restrict access to local files with LocalFileSystem [\#312](https://github.com/apache/arrow-rs-object-store/issues/312)
+- Query on usage of experimental package ring [\#310](https://github.com/apache/arrow-rs-object-store/issues/310)
+- \[EPIC\] Port object\_store content from arrow-rs repository [\#2](https://github.com/apache/arrow-rs-object-store/issues/2)
+- \[Object Store\] Make the service account used when interacting with the metadata url more flexible [\#265](https://github.com/apache/arrow-rs-object-store/issues/265)
 
 **Merged pull requests:**
 
-- ObjectStore WASM32 Support [\#7226](https://github.com/apache/arrow-rs/pull/7226) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
-- \[main\] Bump arrow version to 54.2.1 \(\#7207\) [\#7212](https://github.com/apache/arrow-rs/pull/7212) ([alamb](https://github.com/alamb))
-- Decouple ObjectStore from Reqwest [\#7183](https://github.com/apache/arrow-rs/pull/7183) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
-- object\_store: Disable all compression formats in HTTP reqwest client [\#7143](https://github.com/apache/arrow-rs/pull/7143) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylewlacy](https://github.com/kylewlacy))
-- refactor: remove unused `async` from `InMemory::entry` [\#7133](https://github.com/apache/arrow-rs/pull/7133) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([crepererum](https://github.com/crepererum))
-- object\_store/gcp: derive Clone for GoogleCloudStorage [\#7112](https://github.com/apache/arrow-rs/pull/7112) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([james-rms](https://github.com/james-rms))
-- Update version to 54.2.0 and add CHANGELOG [\#7110](https://github.com/apache/arrow-rs/pull/7110) ([alamb](https://github.com/alamb))
-- Remove all RCs after release [\#7060](https://github.com/apache/arrow-rs/pull/7060) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kou](https://github.com/kou))
-- Update release schedule README.md [\#7053](https://github.com/apache/arrow-rs/pull/7053) ([alamb](https://github.com/alamb))
-- Create GitHub releases automatically on tagging [\#7042](https://github.com/apache/arrow-rs/pull/7042) ([kou](https://github.com/kou))
-- Change Log On Succesful S3 Copy / Multipart Upload to Debug [\#7033](https://github.com/apache/arrow-rs/pull/7033) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([diptanu](https://github.com/diptanu))
-- Prepare for `54.1.0` release [\#7031](https://github.com/apache/arrow-rs/pull/7031) ([alamb](https://github.com/alamb))
-- Add a custom implementation `LocalFileSystem::list_with_offset`  [\#7019](https://github.com/apache/arrow-rs/pull/7019) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([corwinjoy](https://github.com/corwinjoy))
-- Improve docs for `AmazonS3Builder::from_env` [\#6977](https://github.com/apache/arrow-rs/pull/6977) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
-- Fix WASM CI for Rust 1.84 release [\#6963](https://github.com/apache/arrow-rs/pull/6963) ([alamb](https://github.com/alamb))
-- Update itertools requirement from 0.13.0 to 0.14.0 in /object\_store [\#6925](https://github.com/apache/arrow-rs/pull/6925) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([dependabot[bot]](https://github.com/apps/dependabot))
-- Fix LocalFileSystem with range request that ends beyond end of file [\#6751](https://github.com/apache/arrow-rs/pull/6751) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([kylebarron](https://github.com/kylebarron))
+- chore: Add anda\_object\_store to README [\#346](https://github.com/apache/arrow-rs-object-store/pull/346) ([zensh](https://github.com/zensh))
+- Update nix requirement from 0.29.0 to 0.30.0 [\#344](https://github.com/apache/arrow-rs-object-store/pull/344) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fix GCP signing token [\#338](https://github.com/apache/arrow-rs-object-store/pull/338) ([jackm-mimica](https://github.com/jackm-mimica))
+- Fix query parameter signing in Azure [\#334](https://github.com/apache/arrow-rs-object-store/pull/334) ([AdamGS](https://github.com/AdamGS))
+- feat: add EKS Pod Identity support \(\#282\) [\#333](https://github.com/apache/arrow-rs-object-store/pull/333) ([andreasbros](https://github.com/andreasbros))
+- feat: Add `SpawnService` and `SpawnedReqwestConnector` for running requests on a different runtime [\#332](https://github.com/apache/arrow-rs-object-store/pull/332) ([ion-elgreco](https://github.com/ion-elgreco))
+- Support `object_store` with wasm: Default wasm32-unknown-unknown HttpConnector [\#329](https://github.com/apache/arrow-rs-object-store/pull/329) ([H-Plus-Time](https://github.com/H-Plus-Time))
+- Enable anonymous access to GCS buckets [\#322](https://github.com/apache/arrow-rs-object-store/pull/322) ([kylebarron](https://github.com/kylebarron))
+- Fix semantic versioning link in README.md [\#317](https://github.com/apache/arrow-rs-object-store/pull/317) ([lewiszlw](https://github.com/lewiszlw))
+- feat: make some helpers/utils public [\#316](https://github.com/apache/arrow-rs-object-store/pull/316) ([crepererum](https://github.com/crepererum))
+- chore: fix `integration` feature [\#314](https://github.com/apache/arrow-rs-object-store/pull/314) ([crepererum](https://github.com/crepererum))
+- Minor: Update release calendar [\#308](https://github.com/apache/arrow-rs-object-store/pull/308) ([alamb](https://github.com/alamb))
+- Update dependabot config after repo move [\#305](https://github.com/apache/arrow-rs-object-store/pull/305) ([mbrobbel](https://github.com/mbrobbel))
+- Update repo link in Cargo.toml [\#304](https://github.com/apache/arrow-rs-object-store/pull/304) ([mbrobbel](https://github.com/mbrobbel))
+- Bump `rand` to 0.9 [\#303](https://github.com/apache/arrow-rs-object-store/pull/303) ([mbrobbel](https://github.com/mbrobbel))
+- Add content length to PUT GCP multipart complete [\#257](https://github.com/apache/arrow-rs-object-store/pull/257) ([jkosh44](https://github.com/jkosh44))
+- Update README.md and Contributing guidelines [\#8](https://github.com/apache/arrow-rs-object-store/pull/8) ([alamb](https://github.com/alamb))
+- Tweaks: homepage and fix RAT [\#7](https://github.com/apache/arrow-rs-object-store/pull/7) ([alamb](https://github.com/alamb))
+- Fix CI jobs [\#6](https://github.com/apache/arrow-rs-object-store/pull/6) ([alamb](https://github.com/alamb))
+- Port `.github` templates and checks to arrow-rs-object-store crate [\#4](https://github.com/apache/arrow-rs-object-store/pull/4) ([alamb](https://github.com/alamb))
+- Import `object_store`, with history, from arrow-rs [\#3](https://github.com/apache/arrow-rs-object-store/pull/3) ([alamb](https://github.com/alamb))
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "object_store"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ versions approximately every 2 months.
 Planned Release Schedule
 
 | Approximate Date | Version  | Notes                          | Ticket                                                             |
-| ---------------- | -------- | ------------------------------ | :----------------------------------------------------------------- |
-| Apr 2025         | `0.12.1` | Minor, NO breaking API changes | [#287](https://github.com/apache/arrow-rs-object-store/issues/287) |
+|------------------|----------| ------------------------------ |:-------------------------------------------------------------------|
+| June 2025        | `0.12.2` | Minor, NO breaking API changes | [#307](https://github.com/apache/arrow-rs-object-store/issues/307) |

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -106,7 +106,7 @@ distribution servers.
 
 While the official release artifact is a signed tarball, we also tag the commit it was created for convenience and code archaeology.
 
-For `object_store` releases, use a string such as `object_store_0.4.0` as the `<version>`.
+Use a string such as `v0.4.0` as the `<version>`.
 
 Create and push the tag thusly:
 

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -53,8 +53,7 @@ fi
 
 object_store_version=$1
 rc=$2
-
-tag=object_store_${object_store_version}
+tag=v${object_store_version}
 
 release=apache-arrow-object-store-rs-${object_store_version}
 distdir=${SOURCE_TOP_DIR}/dev/dist/${release}-rc${rc}
@@ -98,16 +97,16 @@ The vote will be open for at least 72 hours.
 [ ] +0
 [ ] -1 Do not release this as Apache Arrow Rust Object Store ${version} because...
 
-[1]: https://github.com/apache/arrow-rs/tree/${release_hash}
+[1]: https://github.com/apache/arrow-rs-object-store/tree/${release_hash}
 [2]: ${url}
-[3]: https://github.com/apache/arrow-rs/blob/${release_hash}/object_store/CHANGELOG.md
-[4]: https://github.com/apache/arrow-rs/blob/main/object_store/dev/release/verify-release-candidate.sh
+[3]: https://github.com/apache/arrow-rs-object-store/blob/${release_hash}/object_store/CHANGELOG.md
+[4]: https://github.com/apache/arrow-rs-object-store/blob/main/object_store/dev/release/verify-release-candidate.sh
 MAIL
 echo "---------------------------------------------------------"
 
 
 # create <tarball> containing the files in git at $release_hash
-# the files in the tarball are prefixed with {object_store_version=} (e.g. 0.4.0)
+# the files in the tarball are prefixed with {tag=} (e.g. 0.4.0)
 mkdir -p ${distdir}
 (cd "${SOURCE_TOP_DIR}" && git archive ${release_hash} --prefix ${release}/ | gzip > ${tarball})
 

--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -22,15 +22,15 @@
 # https://github.com/github-changelog-generator/github-changelog-generator
 #
 # With the config located in
-# arrow-rs/object_store/.github_changelog_generator
+# arrow-rs-object-store/.github_changelog_generator
 #
 # Usage:
 # CHANGELOG_GITHUB_TOKEN=<TOKEN> ./update_change_log.sh
 
 set -e
 
-SINCE_TAG="object_store_0.11.2"
-FUTURE_RELEASE="object_store_0.12.0"
+SINCE_TAG="v0.12.0"
+FUTURE_RELEASE="v0.12.1"
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_TOP_DIR="$(cd "${SOURCE_DIR}/../../" && pwd)"
@@ -40,8 +40,6 @@ OUTPUT_PATH="${SOURCE_TOP_DIR}/CHANGELOG.md"
 # remove license header so github-changelog-generator has a clean base to append
 sed -i.bak '1,18d' "${OUTPUT_PATH}"
 
-# use exclude-tags-regex to filter out tags used for arrow
-# crates and only look at tags that begin with `object_store_`
 pushd "${SOURCE_TOP_DIR}"
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator \
     --user apache \
@@ -50,8 +48,6 @@ docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pw
     --cache-log=.githubchangeloggenerator.cache.log \
     --http-cache \
     --max-issues=600 \
-    --include-labels="object-store" \
-    --exclude-tags-regex "(^\d+\.\d+\.\d+$)|(rc)" \
     --since-tag ${SINCE_TAG} \
     --future-release ${FUTURE_RELEASE}
 

--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -43,7 +43,7 @@ sed -i.bak '1,18d' "${OUTPUT_PATH}"
 pushd "${SOURCE_TOP_DIR}"
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator \
     --user apache \
-    --project arrow-rs \
+    --project arrow-rs-object-store \
     --cache-file=.githubchangeloggenerator.cache \
     --cache-log=.githubchangeloggenerator.cache.log \
     --http-cache \


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs-object-store/issues/287

# Rationale for this change
 
Time to release

Note this will be the first release after the object store code was moved into its own repo
- https://github.com/apache/arrow-rs/issues/6183

# What changes are included in this PR?
1. Update Changelog. See rendered version here: [prepare_0.12.1/CHANGELOG.md](https://github.com/alamb/arrow-rs-object-store/blob/alamb/prepare_0.12.1/CHANGELOG.md)
2. Update version
3. Update scripts to work (hopefully) in new repo

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
