### PR TITLE
fix: treat TCP reset as a retryable error

### DIFF
--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -114,6 +114,7 @@ impl HttpError {
                 match e.kind() {
                     std::io::ErrorKind::TimedOut => kind = HttpErrorKind::Timeout,
                     std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::ConnectionReset
                     | std::io::ErrorKind::BrokenPipe
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #350.

# Rationale for this change

We want object_store to retry the request in case the connection closed abruptly.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Map `std::io::ErrorKind::ConnectionReset` -> `HttpErrorKind::Interrupted`

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
