### PR TITLE
Move payload methods from `GetResult` onto `GetResultPayload`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1102,6 +1102,10 @@ impl GetResultPayload {
     ///
     /// If not called from a tokio context, this will perform IO on the current thread with
     /// no additional complexity or overheads
+    #[cfg_attr(
+        not(all(feature = "fs", not(target_arch = "wasm32"))),
+        allow(unused_variables)
+    )]
     pub fn into_stream(self, range: Range<u64>) -> BoxStream<'static, Result<Bytes>> {
         match self {
             #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,18 +1118,7 @@ impl GetResult {
 
     /// Converts this into a byte stream
     ///
-    /// If the `self.kind` is [`GetResultPayload::File`] will perform chunked reads of the file,
-    /// otherwise will return the [`GetResultPayload::Stream`].
-    ///
-    /// # Tokio Compatibility
-    ///
-    /// Tokio discourages performing blocking IO on a tokio worker thread, however,
-    /// no major operating systems have stable async file APIs. Therefore if called from
-    /// a tokio context, this will use [`tokio::runtime::Handle::spawn_blocking`] to dispatch
-    /// IO to a blocking thread pool, much like `tokio::fs` does under-the-hood.
-    ///
-    /// If not called from a tokio context, this will perform IO on the current thread with
-    /// no additional complexity or overheads
+    /// See [`GetResultPayload::into_stream`] for more details.
     pub fn into_stream(self) -> BoxStream<'static, Result<Bytes>> {
         self.payload.into_stream(self.range)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1055,6 +1055,8 @@ impl Debug for GetResultPayload {
 
 impl GetResultPayload {
     /// Collects the data into a [`Bytes`]
+    ///
+    /// Note that the `range` parameter is only used when the payload is a [file][Self::File].
     pub async fn bytes(self, range: Range<u64>) -> Result<Bytes> {
         let len = range.end - range.start;
         match self {
@@ -1088,6 +1090,8 @@ impl GetResultPayload {
     ///
     /// If the `self.kind` is [`GetResultPayload::File`] will perform chunked reads of the file,
     /// otherwise will return the [`GetResultPayload::Stream`].
+    ///
+    /// Note that the `range` parameter is only used when the payload is a [file][Self::File].
     ///
     /// # Tokio Compatibility
     ///


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #352.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Move payload helpers from `GetResult` to `GetResultPayload`.

This is **not** a breaking change because the helpers still exist on `GetResult` too.

# Are there any user-facing changes?

Only added methods.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
