### PR TITLE
Fix `cargo publish` by specifying version for wasm-bindgen-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12", features = ["gzip"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
-wasm-bindgen-test = "*"
+wasm-bindgen-test = "0.3.50"
 
 [dev-dependencies.getrandom_v03]
 package = "getrandom"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/arrow-rs-object-store/issues/357

# Rationale for this change
 
I can't run `cargo publish` without doing this first

# What changes are included in this PR?

See subject

# Are there any user-facing changes?

No, this affects testing and release, not users