### PR TITLE
Add ObjectStoreUrl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,7 +560,7 @@ pub mod integration;
 
 pub use attributes::*;
 
-pub use parse::{parse_url, parse_url_opts, ObjectStoreScheme};
+pub use parse::{parse_url, parse_url_opts, ObjectStoreScheme, ObjectStoreUrl};
 pub use payload::*;
 pub use upload::*;
 pub use util::{coalesce_ranges, collect_bytes, GetRange, OBJECT_STORE_COALESCE_DEFAULT};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -82,12 +82,12 @@ impl ObjectStoreUrl {
         };
 
         let (scheme, store_url, path) = match (url.scheme(), url.host_str()) {
-            ("file", _) => (
+            ("file", None) => (
                 ObjectStoreScheme::Local,
                 url[url::Position::BeforeScheme..url::Position::AfterHost].to_string(),
                 &url[url::Position::BeforeHost..url::Position::AfterPath],
             ),
-            ("memory", _) => (
+            ("memory", None) => (
                 ObjectStoreScheme::Memory,
                 url[url::Position::BeforeScheme..url::Position::AfterHost].to_string(),
                 &url[url::Position::BeforeHost..url::Position::AfterPath],
@@ -250,6 +250,7 @@ impl ObjectStoreScheme {
     /// assert_eq!(scheme, ObjectStoreScheme::Http);
     /// assert_eq!(path.as_ref(), "path/to/my/file");
     /// ```
+    #[deprecated(note = "Use `ObjectStoreUrl::parse` instead")]
     pub fn parse(url: &Url) -> Result<(Self, Path), Error> {
         let os_url = ObjectStoreUrl::parse(url)?;
         Ok((os_url.scheme(), os_url.path().clone()))


### PR DESCRIPTION
I took a crack at adding an `ObjectStoreUrl`, which makes it easier to track store URLs in addition to paths when calling parse_url and when using `ObjectStoreRegistry` in #348. I updated `ObjectStoreScheme::parse` to use `ObjectStore::url` under the hood, and deprecated the old parse method.

Note: I opted to leave usernames, but strip passwords for URLs in the `ObjectStoreUrl::parse` method.

Fixes #356