### PR TITLE
Add PaginatedListStore

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -38,7 +38,7 @@ use url::Url;
 
 use crate::aws::client::{CompleteMultipartMode, PutPartPayload, RequestError, S3Client};
 use crate::client::get::GetClientExt;
-use crate::client::list::ListClientExt;
+use crate::client::list::{ListClient, ListClientExt};
 use crate::client::CredentialProvider;
 use crate::multipart::{MultipartStore, PartId};
 use crate::signer::Signer;
@@ -79,6 +79,7 @@ const STORE: &str = "S3";
 pub type AwsCredentialProvider = Arc<dyn CredentialProvider<Credential = AwsCredential>>;
 use crate::client::parts::Parts;
 pub use credential::{AwsAuthorizer, AwsCredential};
+use crate::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
 
 /// Interface for [Amazon S3](https://aws.amazon.com/s3/).
 #[derive(Debug, Clone)]
@@ -493,6 +494,13 @@ impl MultipartStore for AmazonS3 {
     }
 }
 
+#[async_trait]
+impl PaginatedListStore for AmazonS3 {
+    async fn list_paginated(&self, prefix: Option<&str>, opts: PaginatedListOptions) -> Result<PaginatedListResult> {
+        self.client.list_request(prefix, opts).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -589,6 +597,7 @@ mod tests {
         signing(&integration).await;
         s3_encryption(&integration).await;
         put_get_attributes(&integration).await;
+        list_paginated(&integration, &integration).await;
 
         // Object tagging is not supported by S3 Express One Zone
         if config.session_provider.is_none() {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -78,8 +78,8 @@ const STORE: &str = "S3";
 /// [`CredentialProvider`] for [`AmazonS3`]
 pub type AwsCredentialProvider = Arc<dyn CredentialProvider<Credential = AwsCredential>>;
 use crate::client::parts::Parts;
-pub use credential::{AwsAuthorizer, AwsCredential};
 use crate::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
+pub use credential::{AwsAuthorizer, AwsCredential};
 
 /// Interface for [Amazon S3](https://aws.amazon.com/s3/).
 #[derive(Debug, Clone)]
@@ -496,7 +496,11 @@ impl MultipartStore for AmazonS3 {
 
 #[async_trait]
 impl PaginatedListStore for AmazonS3 {
-    async fn list_paginated(&self, prefix: Option<&str>, opts: PaginatedListOptions) -> Result<PaginatedListResult> {
+    async fn list_paginated(
+        &self,
+        prefix: Option<&str>,
+        opts: PaginatedListOptions,
+    ) -> Result<PaginatedListResult> {
         self.client.list_request(prefix, opts).await
     }
 }

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -1018,7 +1018,7 @@ impl ListClient for Arc<AzureClient> {
         let mut response: ListResultInternal = quick_xml::de::from_reader(response.reader())
             .map_err(|source| Error::InvalidListResponse { source })?;
 
-        let token = response.next_marker.take();
+        let token = response.next_marker.take().filter(|x| !x.is_empty());
 
         Ok(PaginatedListResult {
             result: to_list_result(response, prefix)?,

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -24,8 +24,8 @@ use crate::client::header::{get_put_result, HeaderConfig};
 use crate::client::list::ListClient;
 use crate::client::retry::RetryExt;
 use crate::client::{GetOptionsExt, HttpClient, HttpError, HttpRequest, HttpResponse};
+use crate::list::{PaginatedListOptions, PaginatedListResult};
 use crate::multipart::PartId;
-use crate::path::DELIMITER;
 use crate::util::{deserialize_rfc1123, GetRange};
 use crate::{
     Attribute, Attributes, ClientOptions, GetOptions, ListResult, ObjectMeta, Path, PutMode,
@@ -961,11 +961,13 @@ impl ListClient for Arc<AzureClient> {
     async fn list_request(
         &self,
         prefix: Option<&str>,
-        delimiter: bool,
-        token: Option<&str>,
-        offset: Option<&str>,
-    ) -> Result<(ListResult, Option<String>)> {
-        assert!(offset.is_none()); // Not yet supported
+        opts: PaginatedListOptions,
+    ) -> Result<PaginatedListResult> {
+        if opts.offset.is_some() {
+            return Err(crate::Error::NotSupported {
+                source: "Azure does not support listing with offsets".into(),
+            });
+        }
 
         let credential = self.get_credential().await?;
         let url = self.config.path_url(&Path::default());
@@ -978,21 +980,29 @@ impl ListClient for Arc<AzureClient> {
             query.push(("prefix", prefix))
         }
 
-        if delimiter {
-            query.push(("delimiter", DELIMITER))
+        if let Some(delimiter) = &opts.delimiter {
+            query.push(("delimiter", delimiter.as_ref()))
         }
 
-        if let Some(token) = token {
-            query.push(("marker", token))
+        if let Some(token) = &opts.page_token {
+            query.push(("marker", token.as_ref()))
+        }
+
+        let max_keys_str;
+        if let Some(max_keys) = &opts.max_keys {
+            max_keys_str = max_keys.to_string();
+            query.push(("maxresults", max_keys_str.as_ref()))
         }
 
         let sensitive = credential
             .as_deref()
             .map(|c| c.sensitive_request())
             .unwrap_or_default();
+
         let response = self
             .client
             .get(url.as_str())
+            .extensions(opts.extensions)
             .query(&query)
             .with_azure_authorization(&credential, &self.config.account)
             .retryable(&self.config.retry_config)
@@ -1010,7 +1020,10 @@ impl ListClient for Arc<AzureClient> {
 
         let token = response.next_marker.take();
 
-        Ok((to_list_result(response, prefix)?, token))
+        Ok(PaginatedListResult {
+            result: to_list_result(response, prefix)?,
+            page_token: token,
+        })
     }
 }
 

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -52,8 +52,9 @@ use http::Method;
 use url::Url;
 
 use crate::client::get::GetClientExt;
-use crate::client::list::ListClientExt;
+use crate::client::list::{ListClient, ListClientExt};
 use crate::client::parts::Parts;
+use crate::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
 use crate::multipart::MultipartStore;
 pub use builder::{GoogleCloudStorageBuilder, GoogleConfigKey};
 pub use credential::{GcpCredential, GcpSigningCredential, ServiceAccountKey};
@@ -268,6 +269,17 @@ impl Signer for GoogleCloudStorage {
     }
 }
 
+#[async_trait]
+impl PaginatedListStore for GoogleCloudStorage {
+    async fn list_paginated(
+        &self,
+        prefix: Option<&str>,
+        opts: PaginatedListOptions,
+    ) -> Result<PaginatedListResult> {
+        self.client.list_request(prefix, opts).await
+    }
+}
+
 #[cfg(test)]
 mod test {
 
@@ -299,6 +311,7 @@ mod test {
             multipart(&integration, &integration).await;
             multipart_race_condition(&integration, true).await;
             multipart_out_of_order(&integration).await;
+            list_paginated(&integration, &integration).await;
             // Fake GCS server doesn't currently honor preconditions
             get_opts(&integration).await;
             put_opts(&integration, true).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,6 +610,8 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     ///
     /// Client should prefer [`ObjectStore::put`] for small payloads, as streaming uploads
     /// typically require multiple separate requests. See [`MultipartUpload`] for more information
+    ///
+    /// For more advanced multipart uploads see [`MultipartStore`](multipart::MultipartStore)
     async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
         self.put_multipart_opts(location, PutMultipartOpts::default())
             .await
@@ -619,6 +621,8 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     ///
     /// Client should prefer [`ObjectStore::put`] for small payloads, as streaming uploads
     /// typically require multiple separate requests. See [`MultipartUpload`] for more information
+    ///
+    /// For more advanced multipart uploads see [`MultipartStore`](multipart::MultipartStore)
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -729,6 +733,8 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// `foo/bar_baz/x`. List is recursive, i.e. `foo/bar/more/x` will be included.
     ///
     /// Note: the order of returned [`ObjectMeta`] is not guaranteed
+    /// 
+    /// For more advanced listing see [`PaginatedListStore`](list::PaginatedListStore)
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>>;
 
     /// List all the objects with the given prefix and a location greater than `offset`
@@ -737,6 +743,8 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// the number of network requests required
     ///
     /// Note: the order of returned [`ObjectMeta`] is not guaranteed
+    ///
+    /// For more advanced listing see [`PaginatedListStore`](list::PaginatedListStore)
     fn list_with_offset(
         &self,
         prefix: Option<&Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,6 +547,7 @@ mod tags;
 
 pub use tags::TagSet;
 
+pub mod list;
 pub mod multipart;
 mod parse;
 mod payload;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// `foo/bar_baz/x`. List is recursive, i.e. `foo/bar/more/x` will be included.
     ///
     /// Note: the order of returned [`ObjectMeta`] is not guaranteed
-    /// 
+    ///
     /// For more advanced listing see [`PaginatedListStore`](list::PaginatedListStore)
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>>;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -72,8 +72,9 @@ pub struct PaginatedListResult {
 pub trait PaginatedListStore: Send + Sync + 'static {
     /// Perform a paginated list request
     ///
-    /// Note: Unlike [`ObjectStore::list`] a trailing delimiter is not
-    /// automatically added to `prefix`  
+    /// Note: the order of returned objects is not guaranteed and
+    /// unlike [`ObjectStore::list`] a trailing delimiter is not
+    /// automatically added to `prefix`
     ///
     /// [`ObjectStore::list`]: crate::ObjectStore::list
     async fn list_paginated(

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Paginated Listing
+
+use super::Result;
+use crate::ListResult;
+use async_trait::async_trait;
+use std::borrow::Cow;
+
+/// Options for a paginated list request
+#[derive(Debug, Default, Clone)]
+pub struct PaginatedListOptions {
+    /// Path to start listing from
+    ///
+    /// Note: Not all stores support this
+    pub offset: Option<String>,
+
+    /// A delimiter use to group keys with a common prefix
+    ///
+    /// Note: Some stores only support `/`
+    pub delimiter: Option<Cow<'static, str>>,
+
+    /// The maximum number of paths to return
+    pub max_keys: Option<usize>,
+
+    /// A page token from a previous request
+    ///
+    /// Note: Behaviour is implementation defined if the previous request
+    /// used a different prefix or options
+    pub page_token: Option<String>,
+
+    /// Implementation-specific extensions. Intended for use by implementations
+    /// that need to pass context-specific information (like tracing spans) via trait methods.
+    ///
+    /// These extensions are ignored entirely by backends offered through this crate.
+    pub extensions: http::Extensions,
+}
+
+/// A [`ListResult`] with optional pagination token
+#[derive(Debug)]
+pub struct PaginatedListResult {
+    /// The list result
+    pub result: ListResult,
+    /// If result set truncated, the pagination token to fetch next results
+    pub page_token: Option<String>,
+}
+
+/// A low-level interface for interacting with paginated listing APIs
+///
+/// Most use-cases should prefer [`ObjectStore::list`] as this is supported by more
+/// backends, including [`LocalFileSystem`], however, [`PaginatedListStore`] can be
+/// used where stateless pagination or non-path segment based listing is required 
+///
+/// [`ObjectStore::list`]: crate::ObjectStore::list
+/// [`LocalFileSystem`]: crate::local::LocalFileSystem
+#[async_trait]
+pub trait PaginatedListStore: Send + Sync + 'static {
+    /// Perform a paginated list request
+    /// 
+    /// Note: Unlike [`ObjectStore::list`] a trailing delimiter is not
+    /// automatically added to `prefix`  
+    /// 
+    /// [`ObjectStore::list`]: crate::ObjectStore::list
+    async fn list_paginated(
+        &self,
+        prefix: Option<&str>,
+        opts: PaginatedListOptions,
+    ) -> Result<PaginatedListResult>;
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -64,17 +64,17 @@ pub struct PaginatedListResult {
 ///
 /// Most use-cases should prefer [`ObjectStore::list`] as this is supported by more
 /// backends, including [`LocalFileSystem`], however, [`PaginatedListStore`] can be
-/// used where stateless pagination or non-path segment based listing is required 
+/// used where stateless pagination or non-path segment based listing is required
 ///
 /// [`ObjectStore::list`]: crate::ObjectStore::list
 /// [`LocalFileSystem`]: crate::local::LocalFileSystem
 #[async_trait]
 pub trait PaginatedListStore: Send + Sync + 'static {
     /// Perform a paginated list request
-    /// 
+    ///
     /// Note: Unlike [`ObjectStore::list`] a trailing delimiter is not
     /// automatically added to `prefix`  
-    /// 
+    ///
     /// [`ObjectStore::list`]: crate::ObjectStore::list
     async fn list_paginated(
         &self,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #291
Closes #327.
Relates to #361
Relates to #295 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There is a desire to expose listing APIs even closer to the object stores themselves, either to support custom pagination or non-path-segment based listing.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a PaginatedListStore in a similar vein to MultipartStore

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
