### PR TITLE
fix: TCP reset retry again and recursively iterates sources 

### DIFF
--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -102,16 +102,12 @@ impl HttpError {
         // Reqwest error variants aren't great, attempt to refine them
         let mut source = e.source();
         while let Some(e) = source {
-            let mut is_hyper_error = false;
-            let mut is_io_error = false;
-
             if let Some(e) = e.downcast_ref::<hyper::Error>() {
                 if e.is_closed() || e.is_incomplete_message() || e.is_body_write_aborted() {
                     kind = HttpErrorKind::Request;
                 } else if e.is_timeout() {
                     kind = HttpErrorKind::Timeout;
                 }
-                is_hyper_error = true;
             }
             if let Some(e) = e.downcast_ref::<std::io::Error>() {
                 match e.kind() {
@@ -122,10 +118,6 @@ impl HttpError {
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}
                 }
-                is_io_error = true;
-            }
-            if is_hyper_error || is_io_error {
-                break;
             }
             source = e.source();
         }

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -102,13 +102,16 @@ impl HttpError {
         // Reqwest error variants aren't great, attempt to refine them
         let mut source = e.source();
         while let Some(e) = source {
+            let mut is_hyper_error = false;
+            let mut is_io_error = false;
+
             if let Some(e) = e.downcast_ref::<hyper::Error>() {
                 if e.is_closed() || e.is_incomplete_message() || e.is_body_write_aborted() {
                     kind = HttpErrorKind::Request;
                 } else if e.is_timeout() {
                     kind = HttpErrorKind::Timeout;
                 }
-                break;
+                is_hyper_error = true;
             }
             if let Some(e) = e.downcast_ref::<std::io::Error>() {
                 match e.kind() {
@@ -119,6 +122,9 @@ impl HttpError {
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}
                 }
+                is_io_error = true;
+            }
+            if is_hyper_error || is_io_error {
                 break;
             }
             source = e.source();


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #368 .

# Rationale for this change
 
https://github.com/apache/arrow-rs-object-store/issues/368, which was closed but we will reopen it because we believe the bug was not completely fixed.  

Based on the description of https://github.com/apache/arrow-rs-object-store/pull/351
> I didn't see it iterates sources recursively, trying to convert to hyper / io errors.
> So we just need to make sure std::io::ErrorKind::ConnectionReset gets converted to HttpErrorKind::Interrupted

I think this PR is really what the comment meant: recursively iterates sources and convert hyper/io errors, because currently `break;` causes pre-mature exit and the inner `io` errors are not getting converted, and the thus we are still experiencing no retry for ConnectionReset.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Removed `break`s.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
