### PR TITLE
refactor: remove file-handle from object store GET operations

### DIFF
--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -20,8 +20,7 @@ use crate::client::retry::RetryContext;
 use crate::client::{HttpResponse, HttpResponseBody};
 use crate::path::Path;
 use crate::{
-    Attribute, Attributes, GetOptions, GetRange, GetResult, GetResultPayload, ObjectMeta, Result,
-    RetryConfig,
+    Attribute, Attributes, GetOptions, GetRange, GetResult, ObjectMeta, Result, RetryConfig,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -185,10 +184,10 @@ impl<T: GetClient> GetContext<T> {
         .map_err(Self::err)?;
 
         let attributes = get_attributes(T::HEADER_CONFIG, &parts.headers).map_err(Self::err)?;
-        let stream = self.retry_stream(body, meta.e_tag.clone(), range.clone());
+        let payload = self.retry_stream(body, meta.e_tag.clone(), range.clone());
 
         Ok(GetResult {
-            payload: GetResultPayload::Stream(stream),
+            payload,
             meta,
             range,
             attributes,

--- a/src/local.rs
+++ b/src/local.rs
@@ -37,8 +37,8 @@ use crate::{
     maybe_spawn_blocking,
     path::{absolute_path_to_url, Path},
     util::InvalidGetRange,
-    Attributes, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, PutMode, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, UploadPart,
+    Attributes, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMode, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, UploadPart,
 };
 
 /// A specialized `Error` for filesystem object store-related errors
@@ -414,8 +414,11 @@ impl ObjectStore for LocalFileSystem {
                 None => 0..meta.size,
             };
 
+            const CHUNK_SIZE: usize = 8 * 1024;
+            let payload = chunked_stream(file, path, range.clone(), CHUNK_SIZE);
+
             Ok(GetResult {
-                payload: GetResultPayload::File(file, path),
+                payload,
                 attributes: Attributes::default(),
                 range,
                 meta,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -29,9 +29,9 @@ use parking_lot::RwLock;
 use crate::multipart::{MultipartStore, PartId};
 use crate::util::InvalidGetRange;
 use crate::{
-    path::Path, Attributes, GetRange, GetResult, GetResultPayload, ListResult, MultipartId,
-    MultipartUpload, ObjectMeta, ObjectStore, PutMode, PutMultipartOpts, PutOptions, PutResult,
-    Result, UpdateVersion, UploadPart,
+    path::Path, Attributes, GetRange, GetResult, ListResult, MultipartId, MultipartUpload,
+    ObjectMeta, ObjectStore, PutMode, PutMultipartOpts, PutOptions, PutResult, Result,
+    UpdateVersion, UploadPart,
 };
 use crate::{GetOptions, PutPayload};
 
@@ -262,7 +262,7 @@ impl ObjectStore for InMemory {
         let stream = futures::stream::once(futures::future::ready(Ok(data)));
 
         Ok(GetResult {
-            payload: GetResultPayload::Stream(stream.boxed()),
+            payload: stream.boxed(),
             attributes: entry.attributes,
             meta,
             range,


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #18.

# Rationale for this change
The file handle has several drawbacks as it does NOT specify the following properties:

- **mode:** Is the file opened read-only or does it also have write access (which would be bad)?
- **seek position:** At which position is the current file "read head"? Are users expected to seek to the file start if they want to read the entire file?
- **direct IO:** Is the file opened using direct IO? (in which case the user would have to read in aligned blocks)
- **exclusive access:** Does the API user have exclusive access to the said file handle (and hence can use seek-based operations) or not (in which case only non-seeking operations like [`read_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.read_at) would be required)

At the same time I suspect that most users copy the file data into a buffer anyways and don't use any kernel-based IO operations like [`sendfile`](https://man.archlinux.org/man/sendfile.2).

All object store users and integrating libraries potentially have to deal with streams AND file handles.

# What changes are included in this PR?
Remove [`GetResultPayload::File`](https://docs.rs/object_store/latest/object_store/enum.GetResultPayload.html#variant.File) (and the entire enum).

# Are there any user-facing changes?
Files are no longer exposed.
