### PR TITLE
LocalFileSystem: let WalkDir return sorted results

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -641,6 +641,7 @@ impl LocalFileSystem {
         let walkdir = WalkDir::new(root_path)
             // Don't include the root directory itself
             .min_depth(1)
+            .sort_by_file_name()
             .follow_links(true);
 
         let maybe_offset = maybe_offset.cloned();


### PR DESCRIPTION
addresses https://github.com/apache/arrow-rs-object-store/issues/388

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs-object-store/issues/388

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

offset listing is only usable if the list results are sorted. Only then can I use a member of the results I already have, to make another call that continues my listing.

# What changes are included in this PR?
Adds `sort_by_file_name()` call to `WalkDir` in `list_with_maybe_offset`. As far as I can tell, this is the only change needed to make local file offset listing possible.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
