### PR TITLE
feat (azure): support for account in `az://` URLs

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -658,8 +658,8 @@ impl MicrosoftAzureBuilder {
         };
 
         match parsed.scheme() {
-            "az" | "adl" | "azure" => self.container_name = Some(validate(host)?),
-            "abfs" | "abfss" => {
+            "adl" | "azure" => self.container_name = Some(validate(host)?),
+            "az" | "abfs" | "abfss" => {
                 // abfs(s) might refer to the fsspec convention abfs://<container>/<path>
                 // or the convention for the hadoop driver abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>
                 if parsed.username().is_empty() {
@@ -1101,6 +1101,14 @@ mod tests {
             .unwrap();
         assert_eq!(builder.account_name, Some("account".to_string()));
         assert_eq!(builder.container_name, Some("file_system".to_string()));
+        assert!(!builder.use_fabric_endpoint.get().unwrap());
+
+        let mut builder = MicrosoftAzureBuilder::new();
+        builder
+            .parse_url("az://container@account.dfs.core.windows.net/path-part/file")
+            .unwrap();
+        assert_eq!(builder.account_name, Some("account".to_string()));
+        assert_eq!(builder.container_name, Some("container".to_string()));
         assert!(!builder.use_fabric_endpoint.get().unwrap());
 
         let mut builder = MicrosoftAzureBuilder::new();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #285 .

# Rationale for this change
 When using a URL of type `az://container@account.dfs.core.windows.net/path-part/file`, the account name wasn't parsed from the URL. It is now done.

# What changes are included in this PR?
The parser logic used for URL scheme `az://` is now the same as that used for `abfs://`

# Are there any user-facing changes?
No. However, they can now use the scheme `az://` just as they used to use `abfs://`