### PR TITLE
Prevent compilation error with all cloud features but fs turned on

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -219,6 +219,7 @@ where
             builder_opts!(crate::http::HttpBuilder, url, _options)
         }
         #[cfg(not(all(
+            feature = "fs",
             feature = "aws",
             feature = "azure",
             feature = "gcp",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #411 .

# Rationale for this change

Allows the crate to compile with `--no-default-features --features=aws,azure,gcp,http`

# What changes are included in this PR?

Adds a missing feature test for including a fallback case in the relevant match statement. I could also add this set of feature flags to CI if desired but not sure it's worth it?

# Are there any user-facing changes?

Just the lack of compilation failure.