### PR TITLE
Fix for URI generation issue #434

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -349,6 +349,33 @@ mod tests {
                 .query(&[("list-type", "2")]),
             "http://example.com/bucket?existing=param&list-type=2",
         );
+
+        // Test multiple parameters
+        assert_request_uri(
+            HttpRequestBuilder::new(client.clone())
+                .uri("http://example.com/bucket")
+                .query(&[("list-type", "2"),
+                    ("prefix", "foo/")]),
+            "http://example.com/bucket?list-type=2&prefix=foo%2F",
+        );
+
+        // Test multiple parameters to existing URI
+        assert_request_uri(
+            HttpRequestBuilder::new(client.clone())
+                .uri("http://example.com/bucket?existing=param")
+                .query(&[("list-type", "2"),
+                    ("prefix", "foo/")]),
+            "http://example.com/bucket?existing=param&list-type=2&prefix=foo%2F",
+        );
+
+        // Test multiple appends
+        assert_request_uri(
+            HttpRequestBuilder::new(client.clone())
+                .uri("http://example.com/bucket?existing=param")
+                .query(&[("list-type", "2")])
+                .query(&[("prefix", "foo/")]),
+            "http://example.com/bucket?existing=param&list-type=2&prefix=foo%2F",
+        );
     }
 
     fn assert_request_uri(builder: HttpRequestBuilder, expected: &str) {


### PR DESCRIPTION
When issuing list requests using the AWS module, we noticed that list objects requests were failing due to a strange URI. We saw the generated URI was

`http://server/bucket?&list-type=2&prefix=foo/`

but it should be

`http://server/bucket?list-type=2&prefix=foo/`

i.e. the query string should not start with an ampersand before the list-type parameter.

# Which issue does this PR close?
Closes #434 

# Rationale for this change
Fixes URI query parameter building to be more standard.

# What changes are included in this PR?
One change to URI building.

# Are there any user-facing changes?
None.
