### PR TITLE
aws: downgrade credential provider info! log messages to debug!

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::info;
+use tracing::debug;
 use url::Url;
 
 /// Default metadata endpoint
@@ -943,7 +943,7 @@ impl AmazonS3Builder {
         } else if self.access_key_id.is_some() || self.secret_access_key.is_some() {
             match (self.access_key_id, self.secret_access_key, self.token) {
                 (Some(key_id), Some(secret_key), token) => {
-                    info!("Using Static credential provider");
+                    debug!("Using Static credential provider");
                     let credential = AwsCredential {
                         key_id,
                         secret_key,
@@ -960,7 +960,7 @@ impl AmazonS3Builder {
             std::env::var("AWS_ROLE_ARN"),
         ) {
             // TODO: Replace with `AmazonS3Builder::credentials_from_env`
-            info!("Using WebIdentity credential provider");
+            debug!("Using WebIdentity credential provider");
 
             let session_name = std::env::var("AWS_ROLE_SESSION_NAME")
                 .unwrap_or_else(|_| "WebIdentitySession".to_string());
@@ -983,7 +983,7 @@ impl AmazonS3Builder {
                 self.retry_config.clone(),
             )) as _
         } else if let Some(uri) = self.container_credentials_relative_uri {
-            info!("Using Task credential provider");
+            debug!("Using Task credential provider");
 
             let options = self.client_options.clone().with_allow_http(true);
 
@@ -998,7 +998,7 @@ impl AmazonS3Builder {
             self.container_credentials_full_uri,
             self.container_authorization_token_file,
         ) {
-            info!("Using EKS Pod Identity credential provider");
+            debug!("Using EKS Pod Identity credential provider");
 
             let options = self.client_options.clone().with_allow_http(true);
 
@@ -1010,7 +1010,7 @@ impl AmazonS3Builder {
                 cache: Default::default(),
             }) as _
         } else {
-            info!("Using Instance credential provider");
+            debug!("Using Instance credential provider");
 
             let token = InstanceCredentialProvider {
                 imdsv1_fallback: self.imdsv1_fallback.get()?,


### PR DESCRIPTION
# Which issue does this PR close?
Given this is a small change, I did not think it was necessary to open an issue. I can do so if necessary.

# Rationale for this change
These log messages are very noisy and it seems like they can be downgraded to debug.

# What changes are included in this PR?
Just downgrading log messages from info to debug

# Are there any user-facing changes?
Users that would previously see `Using * credential provider` log messages with info level will not see them any more.