### PR TITLE
feat: re-export HTTP types used in public API

### DIFF
--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -19,8 +19,8 @@
 
 use crate::path::Path;
 use crate::{
-    Attributes, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayloadMut, TagSet,
-    WriteMultipart,
+    Attributes, Extensions, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions,
+    PutPayloadMut, TagSet, WriteMultipart,
 };
 use bytes::Bytes;
 use futures::future::{BoxFuture, FutureExt};
@@ -222,7 +222,7 @@ pub struct BufWriter {
     max_concurrency: usize,
     attributes: Option<Attributes>,
     tags: Option<TagSet>,
-    extensions: Option<::http::Extensions>,
+    extensions: Option<Extensions>,
     state: BufWriterState,
     store: Arc<dyn ObjectStore>,
 }
@@ -297,7 +297,7 @@ impl BufWriter {
     /// that need to pass context-specific information (like tracing spans) via trait methods.
     ///
     /// These extensions are ignored entirely by backends offered through this crate.
-    pub fn with_extensions(self, extensions: ::http::Extensions) -> Self {
+    pub fn with_extensions(self, extensions: Extensions) -> Self {
         Self {
             extensions: Some(extensions),
             ..self


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #263 .

# Rationale for this change
 
User convenience.

# What changes are included in this PR?

Re-export `HeaderMap`, `HeaderValue`, and `Extensions` from http crate to avoid forcing users to add http dependency when using object_store public API.

# Are there any user-facing changes?

The types `HeaderMap`, `HeaderValue`, and `Extensions` can now be accessed directly from object-store without adding http as a separate dependency.