### PR TITLE
Dont unwrap on body send

### DIFF
--- a/src/client/http/spawn.rs
+++ b/src/client/http/spawn.rs
@@ -83,7 +83,9 @@ impl<T: HttpService + Clone> HttpService for SpawnService<T> {
             }
 
             while let Some(x) = body.frame().await {
-                sender.send(x).unwrap();
+                if sender.send(x).is_err() {
+                    return;
+                }
             }
         }));
 


### PR DESCRIPTION
# Rationale for this change

Spawn service was panicking when it was trying to write out the body to the channel.

# What changes are included in this PR?

This PR adjusts the spawn service so it doesn't panic, but instead just finishes off the task.

# Are there any user-facing changes?

No



# Side Note

 I think you should really ban the use of `unwrap` in any code in this project (besides tests).  You can do so with clippy pretty easily