### PR TITLE
Fix not retrying connection errors

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -506,14 +506,21 @@ impl RetryExt for HttpRequestBuilder {
 #[cfg(test)]
 mod tests {
     use crate::client::mock_server::MockServer;
-    use crate::client::retry::{body_contains_error, RequestError, RetryExt};
-    use crate::client::HttpClient;
+    use crate::client::retry::{body_contains_error, RequestError, RetryContext, RetryExt};
+    use crate::client::{HttpClient, HttpResponse};
     use crate::RetryConfig;
+    use http::StatusCode;
     use hyper::header::LOCATION;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
     use hyper::Response;
-    use reqwest::{Client, Method, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use reqwest::{Client, Method};
+    use std::convert::Infallible;
     use std::error::Error;
     use std::time::Duration;
+    use tokio::net::TcpListener;
+    use tokio::time::timeout;
 
     #[test]
     fn test_body_contains_error() {
@@ -817,5 +824,56 @@ mod tests {
 
         // Shutdown
         mock.shutdown().await
+    }
+
+    #[tokio::test]
+    async fn test_connection_reset_is_retried() {
+        let retry = RetryConfig {
+            backoff: Default::default(),
+            max_retries: 2,
+            retry_timeout: Duration::from_secs(1),
+        };
+        assert!(retry.max_retries > 0);
+
+        // Setup server which resets a connection and then quits
+        let listener = TcpListener::bind("::1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let handle = tokio::spawn(async move {
+            // Reset the connection on the first n-1 attempts
+            for _ in 0..retry.max_retries {
+                let (stream, _) = listener.accept().await.unwrap();
+                stream.set_linger(Some(Duration::from_secs(0))).unwrap();
+            }
+            // Succeed on the last attempt
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = http1::Builder::new()
+                // we want the connection to end after responding
+                .keep_alive(false)
+                .serve_connection(
+                    TokioIo::new(stream),
+                    service_fn(move |_req| async {
+                        Ok::<_, Infallible>(HttpResponse::new("Success!".to_string().into()))
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+
+        // Perform the request
+        let client = HttpClient::new(reqwest::Client::new());
+        let ctx = &mut RetryContext::new(&retry);
+        let res = client
+            .get(url)
+            .retryable_request()
+            .send(ctx)
+            .await
+            .expect("request should eventually succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(ctx.exhausted());
+
+        // Wait for server to shutdown
+        let _ = timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("shutdown shouldn't hang");
     }
 }

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -846,7 +846,7 @@ mod tests {
             }
             // Succeed on the last attempt
             let (stream, _) = listener.accept().await.unwrap();
-            let _ = http1::Builder::new()
+            http1::Builder::new()
                 // we want the connection to end after responding
                 .keep_alive(false)
                 .serve_connection(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #368.

# Rationale for this change

As described in #368 connection reset errors aren't being retried due to them being identified as `HttpErrorKind::Unknown` rather than `HttpErrorKind::Interrupted`. This is because the `reqwest::Error` has kind unknown and its immediate source error is a generic `Request` error however if you continue following the error source we eventually get to a `std::io::ErrorKind::ConnectionReset` error.

# What changes are included in this PR?

Currently we stop refining the HTTP error kind once we've been able to downcast the error to either a `hyper::Error` or `std::io::Error` regardless of whether or not we were able to provide a more useful error kind.
This PR changes that so that we keep on refining until we are able to provide a more useful error kind (i.e. not unknown) or we run out of nested errors to check. Because we are only refining while the error kind is unknown, we are not going to accidentally override a more specific error kind with a more generic one.

A test is also included which demonstrates the fix and prevents future regressions.

# Are there any user-facing changes?

No.