### PR TITLE
Add implementation specific attributes

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -49,6 +49,13 @@ pub enum Attribute {
     ///
     /// The String is a user-defined key
     Metadata(Cow<'static, str>),
+    /// Specifies an implementation-specific attribute to be sent with the object
+    ///
+    /// Attribute is prefixed with implementation-defined prefixes are as follows:
+    /// - [`AWS`](crate::aws): `x-amz-`
+    /// - [`Azure`](crate::azure): `x-ms-`
+    /// - [`GCP`](crate::gcp): `x-goog-`
+    Other(Cow<'static, str>),
 }
 
 /// The value of an [`Attribute`]
@@ -199,10 +206,11 @@ mod tests {
             (Attribute::ContentType, "test"),
             (Attribute::CacheControl, "control"),
             (Attribute::Metadata("key1".into()), "value1"),
+            (Attribute::Other("key2".into()), "value2"),
         ]);
 
         assert!(!attributes.is_empty());
-        assert_eq!(attributes.len(), 6);
+        assert_eq!(attributes.len(), 7);
 
         assert_eq!(
             attributes.get(&Attribute::ContentType),
@@ -215,18 +223,18 @@ mod tests {
             attributes.insert(Attribute::CacheControl, "v1".into()),
             Some(metav)
         );
-        assert_eq!(attributes.len(), 6);
+        assert_eq!(attributes.len(), 7);
 
         assert_eq!(
             attributes.remove(&Attribute::CacheControl).unwrap(),
             "v1".into()
         );
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(attributes.len(), 6);
 
         let metav: AttributeValue = "v2".into();
         attributes.insert(Attribute::CacheControl, metav.clone());
         assert_eq!(attributes.get(&Attribute::CacheControl), Some(&metav));
-        assert_eq!(attributes.len(), 6);
+        assert_eq!(attributes.len(), 7);
 
         assert_eq!(
             attributes.get(&Attribute::ContentDisposition),
@@ -243,6 +251,10 @@ mod tests {
         assert_eq!(
             attributes.get(&Attribute::Metadata("key1".into())),
             Some(&"value1".into())
+        );
+        assert_eq!(
+            attributes.get(&Attribute::Other("key2".into())),
+            Some(&"value2".into())
         );
     }
 }

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -59,6 +59,7 @@ use std::sync::Arc;
 
 const VERSION_HEADER: &str = "x-amz-version-id";
 const SHA256_CHECKSUM: &str = "x-amz-checksum-sha256";
+const IMPL_DEFINED_ATTR_HEADER_PREFIX: &str = "x-amz-";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-amz-meta-";
 const ALGORITHM: &str = "x-amz-checksum-algorithm";
 
@@ -375,6 +376,10 @@ impl Request<'_> {
                 }
                 Attribute::Metadata(k_suffix) => builder.header(
                     &format!("{USER_DEFINED_METADATA_HEADER_PREFIX}{k_suffix}"),
+                    v.as_ref(),
+                ),
+                Attribute::Other(attr) => builder.header(
+                    &format!("{IMPL_DEFINED_ATTR_HEADER_PREFIX}{attr}"),
                     v.as_ref(),
                 ),
             };

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -49,6 +49,7 @@ use url::Url;
 
 const VERSION_HEADER: &str = "x-ms-version-id";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-ms-meta-";
+const IMPL_DEFINED_ATTR_HEADER_PREFIX: &str = "x-ms-";
 static MS_CACHE_CONTROL: HeaderName = HeaderName::from_static("x-ms-blob-cache-control");
 static MS_CONTENT_TYPE: HeaderName = HeaderName::from_static("x-ms-blob-content-type");
 static MS_CONTENT_DISPOSITION: HeaderName =
@@ -244,6 +245,10 @@ impl PutRequest<'_> {
                 }
                 Attribute::Metadata(k_suffix) => builder.header(
                     &format!("{USER_DEFINED_METADATA_HEADER_PREFIX}{k_suffix}"),
+                    v.as_ref(),
+                ),
+                Attribute::Other(attr) => builder.header(
+                    &format!("{IMPL_DEFINED_ATTR_HEADER_PREFIX}{attr}"),
                     v.as_ref(),
                 ),
             };

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 const VERSION_HEADER: &str = "x-goog-generation";
 const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-goog-meta-";
+const IMPL_DEFINED_ATTR_HEADER_PREFIX: &str = "x-goog-";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
 
@@ -203,6 +204,10 @@ impl Request<'_> {
                 }
                 Attribute::Metadata(k_suffix) => builder.header(
                     &format!("{USER_DEFINED_METADATA_HEADER_PREFIX}{k_suffix}"),
+                    v.as_ref(),
+                ),
+                Attribute::Other(attr) => builder.header(
+                    &format!("{IMPL_DEFINED_ATTR_HEADER_PREFIX}{attr}"),
                     v.as_ref(),
                 ),
             };

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -198,6 +198,7 @@ impl Client {
                     }
                     // Ignore metadata attributes
                     Attribute::Metadata(_) => builder,
+                    Attribute::Other(attr) => builder.header(&**attr, v.as_ref()),
                 };
             }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #446.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Currently there seems to be no support for applying implementation specific attributes within this API. For example with a `aws_store.put_opts(...)` call, there would be no way to specify a [`x-amz-object-lock-mode` attribute](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax), or applying [`x-goog-storage-class`](https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogstorageclass) for a GCP put operation. This adds support for such use cases.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Expands the `Attribute` enum to include a `Other` variant that will add headers with implementation specific prefixes (`x-amz-` for AWS, etc.)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, documentation was updated where I thought needed. Let me know if more is needed.

<!---
If there are any breaking changes to public APIs, please call them out.
-->

These changes should be backwards compatible.
