### PR TITLE
chore: replace deprecated StepRng with custom implementation

### DIFF
--- a/src/client/backoff.rs
+++ b/src/client/backoff.rs
@@ -110,7 +110,22 @@ impl Backoff {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rngs::mock::StepRng;
+
+    /// An rng for testing that always returns the same value.
+    struct ConstRng(u64);
+    impl RngCore for ConstRng {
+        fn next_u32(&mut self) -> u32 {
+            unimplemented!()
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.0
+        }
+
+        fn fill_bytes(&mut self, _: &mut [u8]) {
+            unimplemented!()
+        }
+    }
 
     #[test]
     fn test_backoff() {
@@ -127,7 +142,7 @@ mod tests {
         let assert_fuzzy_eq = |a: f64, b: f64| assert!((b - a).abs() < 0.0001, "{a} != {b}");
 
         // Create a static rng that takes the minimum of the range
-        let rng = Box::new(StepRng::new(0, 0));
+        let rng = Box::new(ConstRng(0));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         for _ in 0..20 {
@@ -135,7 +150,7 @@ mod tests {
         }
 
         // Create a static rng that takes the maximum of the range
-        let rng = Box::new(StepRng::new(u64::MAX, 0));
+        let rng = Box::new(ConstRng(u64::MAX));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         for i in 0..20 {
@@ -144,7 +159,7 @@ mod tests {
         }
 
         // Create a static rng that takes the mid point of the range
-        let rng = Box::new(StepRng::new(u64::MAX / 2, 0));
+        let rng = Box::new(ConstRng(u64::MAX / 2));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         let mut value = init_backoff_secs;


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
StepRng is deprecated.

# What changes are included in this PR?

Removes the use of deprecated StepRng.

# Are there any user-facing changes?

No.