### PR TITLE
Add support for Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 serde_urlencoded = { version = "0.7", optional = true }
 tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 
+[target.'cfg(target_os="android")'.dependencies]
+nix = { version = "0.30.0" }
+
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.30.0", features = ["fs"] }
 


### PR DESCRIPTION
Android doesn't support hard_link so provide an alternate path for performing the requested operation.

# Which issue does this PR close?

Closes #459.

# Rationale for this change
 
On Android hard links are not allowed. However, there are alternate ways to express atomicity of the same operations - we use OpenOptions::create_new instead to guarantee the target exists or not before clobbering it.

# What changes are included in this PR?

LocalFilesystem put/copy/copy_if_not_exists alternatives for Android that don't use hard_link.

# Are there any user-facing changes?

No.