### PR TITLE
Optional put idempotency.

### DIFF
--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -550,6 +550,7 @@ impl AzureClient {
             tags,
             attributes,
             extensions,
+            idempotent,
         } = opts;
 
         let builder = self
@@ -560,10 +561,10 @@ impl AzureClient {
 
         let builder = match &mode {
             PutMode::Overwrite => builder.idempotent(true),
-            PutMode::Create => builder.header(&IF_NONE_MATCH, "*"),
+            PutMode::Create => builder.header(&IF_NONE_MATCH, "*").idempotent(idempotent),
             PutMode::Update(v) => {
                 let etag = v.e_tag.as_ref().ok_or(Error::MissingETag)?;
-                builder.header(&IF_MATCH, etag)
+                builder.header(&IF_MATCH, etag).idempotent(idempotent)
             }
         };
 

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -387,6 +387,7 @@ impl GoogleCloudStorageClient {
             tags: _,
             attributes,
             extensions,
+            idempotent,
         } = opts;
 
         let builder = self
@@ -397,10 +398,10 @@ impl GoogleCloudStorageClient {
 
         let builder = match &mode {
             PutMode::Overwrite => builder.idempotent(true),
-            PutMode::Create => builder.header(&VERSION_MATCH, "0"),
+            PutMode::Create => builder.header(&VERSION_MATCH, "0").idempotent(idempotent),
             PutMode::Update(v) => {
                 let etag = v.version.as_ref().ok_or(Error::MissingVersion)?;
-                builder.header(&VERSION_MATCH, etag)
+                builder.header(&VERSION_MATCH, etag).idempotent(idempotent)
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1188,6 +1188,11 @@ pub struct PutOptions {
     ///
     /// They are also eclused from [`PartialEq`] and [`Eq`].
     pub extensions: Extensions,
+    /// Whether to flag create and update operations as idempotent
+    ///
+    /// This is useful for applications that want to retry put operations that fail
+    /// for unexpected reasons, like timeouts.
+    pub idempotent: bool,
 }
 
 impl PartialEq<Self> for PutOptions {
@@ -1197,14 +1202,16 @@ impl PartialEq<Self> for PutOptions {
             tags,
             attributes,
             extensions: _,
+            idempotent,
         } = self;
         let Self {
             mode: other_mode,
             tags: other_tags,
             attributes: other_attributes,
             extensions: _,
+            idempotent: other_idempotent,
         } = other;
-        (mode == other_mode) && (tags == other_tags) && (attributes == other_attributes)
+        (mode == other_mode) && (tags == other_tags) && (attributes == other_attributes) && (idempotent == other_idempotent)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs-object-store/issues/464.

# Rationale for this change

Put operations in object store are usually idempotent. However, that guarantee does not exist since this crate calls APIs that it does not control.

Some clients might want to take the risk of ensuring all `put` operations are idempotent, and retried when unexpected errors happen, like SlateDB.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

This change introduces a new flag in `PutOptions` to let callers mark the `put` operation as idempotent, triggering the retry logic that the underlying HTTP client implements.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, there is a new flag in `PutOptions` that users can enable. I've included rustdoc changes with the new flag.

<!---
If there are any breaking changes to public APIs, please call them out.
-->
