### PR TITLE
Allow "application_credentials" in `impl FromStr for GoogleConfigKey`

### DIFF
--- a/src/gcp/builder.rs
+++ b/src/gcp/builder.rs
@@ -195,7 +195,9 @@ impl FromStr for GoogleConfigKey {
             | "service_account_path" => Ok(Self::ServiceAccount),
             "google_service_account_key" | "service_account_key" => Ok(Self::ServiceAccountKey),
             "google_bucket" | "google_bucket_name" | "bucket" | "bucket_name" => Ok(Self::Bucket),
-            "google_application_credentials" => Ok(Self::ApplicationCredentials),
+            "google_application_credentials" | "application_credentials" => {
+                Ok(Self::ApplicationCredentials)
+            }
             "google_skip_signature" | "skip_signature" => Ok(Self::SkipSignature),
             _ => match s.strip_prefix("google_").unwrap_or(s).parse() {
                 Ok(key) => Ok(Self::Client(key)),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
In general, all config keys have a `FromStr` implementation that allows either a store-prefixed parameter name, or the same name without the prefix. 

I.e. `"google_service_account"` and `"service_account"` are both valid string keys for `GoogleConfigKey::ServiceAccount`. 

But `"google_application_credentials"` does not follow this symmetry. It would be more predictable if it did.

# What changes are included in this PR?

Allow `"application_credentials"` as a string key for `GoogleConfigKey::ApplicationCredentials`.

# Are there any user-facing changes?

Yes, new string allowed for config key.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
