### PR TITLE
Make RetryError and RequestError public.

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -108,19 +108,30 @@ impl RetryContext {
 /// The reason a request failed
 #[derive(Debug, thiserror::Error)]
 pub enum RequestError {
+    /// Received redirect without LOCATION, this normally indicates an incorrectly configured region
     #[error("Received redirect without LOCATION, this normally indicates an incorrectly configured region"
     )]
     BareRedirect,
 
+    /// Server returned non-2xx status code
     #[error("Server returned non-2xx status code: {status}: {}", body.as_deref().unwrap_or(""))]
     Status {
+        /// The status code returned by the server
         status: StatusCode,
+        /// The body of the response
         body: Option<String>,
     },
 
+    /// Server returned error response
     #[error("Server returned error response: {body}")]
-    Response { status: StatusCode, body: String },
+    Response {
+        /// The status code returned by the server
+        status: StatusCode,
+        /// The body of the response
+        body: String,
+    },
 
+    /// Server returned a generic HTTP error
     #[error(transparent)]
     Http(#[from] HttpError),
 }
@@ -150,6 +161,7 @@ impl RetryError {
         }
     }
 
+    /// Convert the retry error to a [`crate::Error`]
     pub fn error(self, store: &'static str, path: String) -> crate::Error {
         match self.status() {
             Some(StatusCode::NOT_FOUND) => crate::Error::NotFound {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,8 +534,9 @@ pub mod client;
 
 #[cfg(feature = "cloud")]
 pub use client::{
-    backoff::BackoffConfig, retry::RetryConfig, ClientConfigKey, ClientOptions, CredentialProvider,
-    StaticCredentialProvider,
+    backoff::BackoffConfig,
+    retry::{RequestError, RetryConfig, RetryError},
+    ClientConfigKey, ClientOptions, CredentialProvider, StaticCredentialProvider,
 };
 
 #[cfg(all(feature = "cloud", not(target_arch = "wasm32")))]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs-object-store/issues/469

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

It's impossible to access the information in a `RetryError` because you cannot downcast an `Error::Generic { source, .. }` into a `RetryError`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR makes the `RetryError` and `RequestError` types public.

# Are there any user-facing changes?

There are two new times exposed publicly.
They both include rustdocs already, and I added new rustdocs in places that were missing.
No breaking changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
