### PR TITLE
Allow setting STS endpoint via env var

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -965,7 +965,8 @@ impl AmazonS3Builder {
             let session_name = std::env::var("AWS_ROLE_SESSION_NAME")
                 .unwrap_or_else(|_| "WebIdentitySession".to_string());
 
-            let endpoint = format!("https://sts.{region}.amazonaws.com");
+            let endpoint = std::env::var("AWS_ENDPOINT_URL_STS")
+                .unwrap_or_else(|_| format!("https://sts.{region}.amazonaws.com"));
 
             // Disallow non-HTTPs requests
             let options = self.client_options.clone().with_allow_http(false);


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs-object-store/issues/283

# Rationale for this change
 
I am using a self-hosted S3 store and want to be able to use the AssumeRoleWithWebIdentity auth flow.

# What changes are included in this PR?

The endpoint used for STS can now be sourced from the [AWS_ENDPOINT_URL_STS](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html#:~:text=more%20path%20segments.-,AWS_ENDPOINT_URL_%3CSERVICE%3E,-%2D%20environment%20variable) env var instead of always being hardcoded to `https://sts.{region}.amazonaws.com`.


# Are there any user-facing changes?

- New ability to set STS endpoint
