### PR TITLE
chore(client/retry): include error info in logs when retry occurs

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -421,7 +421,8 @@ impl RetryableRequest {
 
                         let sleep = ctx.backoff();
                         info!(
-                            "Encountered server error, backing off for {} seconds, retry {} of {}",
+                            "Encountered server error with status {}, backing off for {} seconds, retry {} of {}",
+                            status,
                             sleep.as_secs_f32(),
                             ctx.retries,
                             ctx.max_retries,
@@ -445,7 +446,8 @@ impl RetryableRequest {
                     }
                     let sleep = ctx.backoff();
                     info!(
-                        "Encountered transport error backing off for {} seconds, retry {} of {}: {}",
+                        "Encountered transport error of kind {:?}, backing off for {} seconds, retry {} of {}: {}",
+                        e.kind(),
                         sleep.as_secs_f32(),
                         ctx.retries,
                         ctx.max_retries,


### PR DESCRIPTION
On a request retry, it logs an info message stating that an error was encountered and information about the retry process but it hasn't included any details about the error that is causing the retry. This PR updates the logging to include the status if it is a server error and the http error kind if a transport error occurred. While the last error when retries are exhausted is returned up the call stack, the intermediate errors need not be exactly the same. It is helpful to include some minimum information about what error triggered a retry each time it happens.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #486

# Rationale for this change
 
More information about the conditions that caused a retry in the http client. This information can help diagnose server or transport issues.

# What changes are included in this PR?

Updates to two `info!` logging statements and nothing else
# Are there any user-facing changes?

Yes, the logged messages will include new information. This shouldn't require any new documentation.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
