### PR TITLE
Add version 0.12.4 release plan to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,6 @@ Planned Release Schedule
 | Approximate Date | Version  | Notes                          | Ticket                                                             |
 |------------------|----------|--------------------------------|:-------------------------------------------------------------------|
 | July 2025        | `0.12.3` | Minor, NO breaking API changes | [#428](https://github.com/apache/arrow-rs-object-store/issues/428) |
+| Sep 2025         | `0.12.4` | Minor, NO breaking API changes | [#498](https://github.com/apache/arrow-rs-object-store/issues/489) |
 | TBD              | `0.13.0` | Major, breaking API changes    | [#367](https://github.com/apache/arrow-rs-object-store/issues/367) |
 | TBD              | `0.13.1` | Minor, NO breaking API changes | [#393](https://github.com/apache/arrow-rs-object-store/issues/393) |


### PR DESCRIPTION
- Related to https://github.com/apache/arrow-rs-object-store/issues/392
- RElated to https://github.com/apache/arrow-rs-object-store/issues/489
Let's plan for a 0.12.4 non-breaking release