### PR TITLE
Fix for clippy 1.90

### DIFF
--- a/src/azure/credential.rs
+++ b/src/azure/credential.rs
@@ -507,7 +507,7 @@ fn string_to_sign(h: &HeaderMap, u: &Url, method: &Method, account: &str) -> Str
 fn canonicalize_header(headers: &HeaderMap) -> String {
     let mut names = headers
         .iter()
-        .filter(|&(k, _)| (k.as_str().starts_with("x-ms")))
+        .filter(|&(k, _)| k.as_str().starts_with("x-ms"))
         // TODO remove unwraps
         .map(|(k, _)| (k.as_str(), headers.get(k).unwrap().to_str().unwrap()))
         .collect::<Vec<_>>();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to https://github.com/apache/arrow-rs-object-store/issues/489
- 
# Rationale for this change
 
Rust 1.90 is released https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/ and clippy got smarter

I would like to have clean CI runs for the next release

Here is an example CI failure: https://github.com/apache/arrow-rs-object-store/actions/runs/17860331710/job/50789123954?pr=491

```
    Checking object_store v0.12.4 (/__w/arrow-rs-object-store/arrow-rs-object-store)
error: unnecessary parentheses around closure body
   --> src/azure/credential.rs:510:27
    |
510 |         .filter(|&(k, _)| (k.as_str().starts_with("x-ms")))
    |                           ^                              ^
    |
    = note: `-D unused-parens` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_parens)]`
help: remove these parentheses
    |
510 -         .filter(|&(k, _)| (k.as_str().starts_with("x-ms")))
510 +         .filter(|&(k, _)| k.as_str().starts_with("x-ms"))
    |

error: could not compile `object_store` (lib) due to 1 previous error
Error: Process completed with exit code 101.
```

# What changes are included in this PR?
Fix extra parenthesis that was triggering clippy  by making the suggestion from clippy
# Are there any user-facing changes?

no