### PR TITLE
Remove unneeded files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ description = "A generic object store interface for uniformly interacting with A
 keywords = ["object", "storage", "cloud"]
 repository = "https://github.com/apache/arrow-rs-object-store"
 rust-version = "1.64.0"
+include = ["src/**/*.rs", "README.md", "LICENSE.txt", "NOTICE.txt", "Cargo.toml"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
# Which issue does this PR close?

None, but I can fill an issue for this change if it's required

# Rationale for this change
 
During a regular review of our dependencies I noticed that the published version of object-store crate contains several unneeded files. This includes various scripts from
[`dev/release`](https://github.com/apache/arrow-rs-object-store/tree/main/dev/release). While these scripts should not be a problem at all, they are still shell scripts that could contain malicous content and that could be executed at compile time. By excluding them it's possible to deny interpreted scripts for this crate by using [`cargo
deny`](https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-interpreted-field-optional)

# What changes are included in this PR?

This commit introduces an explicit `include` list in the `Cargo.toml` file to ensure only required files are included. I've choosen to only include relevant source code files. I personally prefer using `include` as it makes clear what should be in the crate rather than relying on `exclude` which only defines what shouldn't be in there.

Finally this change reduces the size of the uploaded package from 93 files, 1.3MiB (269.5KiB compressed) to 65 files, 1.1MiB (232.3KiB compressed), which results in a ~68GB/month traffic reduction for crates.io assuming the current ~2 million downloads per month and the compressed package sizes.

# Are there any user-facing changes?

Smaller package sizes + removed release scripts. Otherwise this shouldn't be user-facing as long as the user doesn't try to:

* Run the release scripts (noone should do that?)
* Tries to run tests from the downloaded crate source (That's done by some linux distributions, although popular crates like [reqwest](https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L15) or  [diesel](https://github.com/diesel-rs/diesel/blob/main/diesel/Cargo.toml#L14) also exclude tests so they cannot really rely on the tests being present already)
