### PR TITLE
chore: fix msrv check by pinning syn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,7 @@ jobs:
           cargo update -p parking_lot --precise 0.12.4
           cargo update -p parking_lot_core --precise 0.9.11
           cargo update -p lock_api --precise 0.4.13
+          cargo update -p syn --precise 2.0.106
       - name: Check
         run: |
           # run `cargo msrv verify` to see problems


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
MSRV check is failing in CI

# What changes are included in this PR?

Pin `syn` to `2.0.106` to exclude https://github.com/dtolnay/syn/commit/9dbb5b7b99711db4958d5087e75da0e99eed6462

# Are there any user-facing changes?

CI