### PR TITLE
Allow parsing S3 URLs without region

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -736,6 +736,10 @@ impl AmazonS3Builder {
                         self.bucket_name = Some(bucket.into());
                     }
                 }
+                Some((bucket, "s3", "amazonaws", "com")) => {
+                    self.bucket_name = Some(bucket.to_string());
+                    self.virtual_hosted_style_request = true.into();
+                }
                 Some((bucket, "s3", region, "amazonaws.com")) => {
                     self.bucket_name = Some(bucket.to_string());
                     self.region = Some(region.to_string());
@@ -1552,6 +1556,13 @@ mod tests {
             .unwrap();
         assert_eq!(builder.region, Some("region".to_string()));
         assert_eq!(builder.bucket_name, Some("bucket.with.dot".to_string()));
+
+        let mut builder = AmazonS3Builder::new();
+        builder
+            .parse_url("https://bucket.s3.amazonaws.com")
+            .unwrap();
+        assert_eq!(builder.bucket_name, Some("bucket".to_string()));
+        assert!(builder.virtual_hosted_style_request.get().unwrap());
 
         let mut builder = AmazonS3Builder::new();
         builder


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs-object-store/issues/522.

# Rationale for this change
 
Allow parsing old-style AWS HTTP urls that don't include bucket region.

# What changes are included in this PR?

Support for URL format.

# Are there any user-facing changes?

No breaking changes, just an added URL format supported.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
