### PR TITLE
Implement ObjectStore for Arc<T> and Box<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1885,9 +1885,8 @@ impl From<Error> for std::io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use chrono::TimeZone;
-    
 
     macro_rules! maybe_skip_integration {
         () => {
@@ -1897,7 +1896,7 @@ mod tests {
             }
         };
     }
-    
+    pub(crate) use maybe_skip_integration;
 
     /// Test that the returned stream does not borrow the lifetime of Path
     fn list_store<'a>(
@@ -1939,6 +1938,9 @@ mod tests {
     {
         use bytes::Buf;
         use serde::Deserialize;
+        use tokio::io::AsyncWriteExt;
+
+        use crate::buffered::BufWriter;
 
         #[derive(Deserialize)]
         struct Tagging {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #525 

# Rationale for this change
 
Allows you to put `Arc<T>` into something like struct `ObjectStoreWrapper<T: ObjectStore>(T)`


# What changes are included in this PR?

Implementing ObjectStore for `Arc<T>` and `Box<T>`

# Are there any user-facing changes?

No and this should not break anything.  Just expand the flexibility of the ObjectStore Trait. 
