### PR TITLE
refactor: move `put_multipart` to `ObjectStoreExt`

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! ## Multipart uploads
 //!
-//! Multipart uploads can be initiated with the [ObjectStore::put_multipart] method.
+//! Multipart uploads can be initiated with the [`ObjectStore::put_multipart_opts`] method.
 //!
 //! If the writer fails for any reason, you may have parts uploaded to AWS but not
 //! used that you will be charged for. [`MultipartUpload::abort`] may be invoked to drop

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! ## Streaming uploads
 //!
-//! [ObjectStore::put_multipart] will upload data in blocks and write a blob from those blocks.
+//! [`ObjectStore::put_multipart_opts`] will upload data in blocks and write a blob from those blocks.
 //!
 //! Unused blocks will automatically be dropped after 7 days.
 use crate::{

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -211,12 +211,12 @@ impl AsyncBufRead for BufReader {
 /// An async buffered writer compatible with the tokio IO traits
 ///
 /// This writer adaptively uses [`ObjectStore::put_opts`] or
-/// [`ObjectStore::put_multipart`] depending on the amount of data that has
+/// [`ObjectStore::put_multipart_opts`] depending on the amount of data that has
 /// been written.
 ///
 /// Up to `capacity` bytes will be buffered in memory, and flushed on shutdown
 /// using [`ObjectStore::put_opts`]. If `capacity` is exceeded, data will instead be
-/// streamed using [`ObjectStore::put_multipart`]
+/// streamed using [`ObjectStore::put_multipart_opts`].
 pub struct BufWriter {
     capacity: usize,
     max_concurrency: usize,
@@ -238,7 +238,7 @@ impl std::fmt::Debug for BufWriter {
 enum BufWriterState {
     /// Buffer up to capacity bytes
     Buffer(Path, PutPayloadMut),
-    /// [`ObjectStore::put_multipart`]
+    /// [`ObjectStore::put_multipart_opts`]
     Prepare(BoxFuture<'static, crate::Result<WriteMultipart>>),
     /// Write to a multipart upload
     Write(Option<WriteMultipart>),

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -71,10 +71,6 @@ impl ObjectStore for ChunkedStore {
         self.inner.put_opts(location, payload, opts).await
     }
 
-    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart(location).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -20,7 +20,7 @@
 //! ## Multipart uploads
 //!
 //! [Multipart uploads](https://cloud.google.com/storage/docs/multipart-uploads)
-//! can be initiated with the [ObjectStore::put_multipart] method. If neither
+//! can be initiated with the [`ObjectStore::put_multipart_opts`] method. If neither
 //! [`MultipartUpload::complete`] nor [`MultipartUpload::abort`] is invoked, you may
 //! have parts uploaded to GCS but not used, that you will be charged for. It is recommended
 //! you configure a [lifecycle rule] to abort incomplete multipart uploads after a certain

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -80,13 +80,6 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.put_opts(location, payload, opts).await
     }
-    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        let upload = self.inner.put_multipart(location).await?;
-        Ok(Box::new(LimitUpload {
-            semaphore: Arc::clone(&self.semaphore),
-            upload,
-        }))
-    }
 
     async fn put_multipart_opts(
         &self,

--- a/src/local.rs
+++ b/src/local.rs
@@ -1719,7 +1719,7 @@ mod not_wasm_tests {
     use tempfile::TempDir;
 
     use crate::local::LocalFileSystem;
-    use crate::{ObjectStore, Path, PutPayload};
+    use crate::{ObjectStoreExt, Path, PutPayload};
 
     #[tokio::test]
     async fn test_cleanup_intermediate_files() {

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -35,11 +35,11 @@ pub struct PartId {
 
 /// A low-level interface for interacting with multipart upload APIs
 ///
-/// Most use-cases should prefer [`ObjectStore::put_multipart`] as this is supported by more
+/// Most use-cases should prefer [`ObjectStore::put_multipart_opts`] as this is supported by more
 /// backends, including [`LocalFileSystem`], and automatically handles uploading fixed
 /// size parts of sufficient size in parallel
 ///
-/// [`ObjectStore::put_multipart`]: crate::ObjectStore::put_multipart
+/// [`ObjectStore::put_multipart_opts`]: crate::ObjectStore::put_multipart_opts
 /// [`LocalFileSystem`]: crate::local::LocalFileSystem
 #[async_trait]
 pub trait MultipartStore: Send + Sync + 'static {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -104,11 +104,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         self.inner.put_opts(&full_path, payload, opts).await
     }
 
-    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        let full_path = self.full_path(location);
-        self.inner.put_multipart(&full_path).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -158,14 +158,6 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         self.inner.put_opts(location, payload, opts).await
     }
 
-    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        let upload = self.inner.put_multipart(location).await?;
-        Ok(Box::new(ThrottledUpload {
-            upload,
-            sleep: self.config().wait_put_per_call,
-        }))
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -248,7 +248,7 @@ mod tests {
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
 
-    use crate::ObjectStore;
+    use crate::ObjectStoreExt;
     use crate::memory::InMemory;
     use crate::path::Path;
     use crate::throttle::{ThrottleConfig, ThrottledStore};


### PR DESCRIPTION
# Which issue does this PR close?
See #385 and #405.

# Rationale for this change
Similar to `put`, `put_multipart` is just `put_multipart_opts` with default options.

# What changes are included in this PR?
1. move method to extension trait
2. remove no-longer-required implementations

# Are there any user-facing changes?
**Breaking:** `put_multipart` moved from `ObjectStore` to `ObjectStoreExt`.
