### PR TITLE
refactor!: move `get` to `ObjectStoreExt`

### DIFF
--- a/src/azure/credential.rs
+++ b/src/azure/credential.rs
@@ -1073,7 +1073,7 @@ mod tests {
     use super::*;
     use crate::azure::MicrosoftAzureBuilder;
     use crate::client::mock_server::MockServer;
-    use crate::{ObjectStore, Path};
+    use crate::{ObjectStoreExt, Path};
 
     #[tokio::test]
     async fn test_managed_identity() {

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -45,13 +45,14 @@ pub const DEFAULT_BUFFER_SIZE: usize = 1024 * 1024;
 /// very [high first-byte latencies], on the order of 100-200ms, and so avoiding unnecessary
 /// round-trips is critical to throughput.
 ///
-/// Systems looking to sequentially scan a file should instead consider using [`ObjectStore::get`],
+/// Systems looking to sequentially scan a file should instead consider using [`ObjectStoreExt::get`],
 /// or [`ObjectStore::get_opts`], or [`ObjectStore::get_range`] to read a particular range.
 ///
 /// Systems looking to read multiple ranges of a file should instead consider using
 /// [`ObjectStore::get_ranges`], which will optimise the vectored IO.
 ///
 /// [high first-byte latencies]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+/// [`ObjectStoreExt::get`]: crate::ObjectStoreExt::get
 pub struct BufReader {
     /// The object store to fetch data from
     store: Arc<dyn ObjectStore>,

--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -487,7 +487,7 @@ mod http_tests {
     use crate::client::{HttpError, HttpErrorKind, HttpResponseBody};
     use crate::http::HttpBuilder;
     use crate::path::Path;
-    use crate::{ClientOptions, ObjectStore, RetryConfig};
+    use crate::{ClientOptions, ObjectStoreExt, RetryConfig};
     use bytes::Bytes;
     use futures::FutureExt;
     use http::header::{CONTENT_LENGTH, CONTENT_RANGE, ETAG, RANGE};

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -93,12 +93,6 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         }))
     }
 
-    async fn get(&self, location: &Path) -> Result<GetResult> {
-        let permit = Arc::clone(&self.semaphore).acquire_owned().await.unwrap();
-        let r = self.inner.get(location).await?;
-        Ok(permit_get_result(r, permit))
-    }
-
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let permit = Arc::clone(&self.semaphore).acquire_owned().await.unwrap();
         let r = self.inner.get_opts(location, options).await?;

--- a/src/local.rs
+++ b/src/local.rs
@@ -1756,7 +1756,7 @@ mod unix_test {
     use tempfile::TempDir;
 
     use crate::local::LocalFileSystem;
-    use crate::{ObjectStore, Path};
+    use crate::{ObjectStore, ObjectStoreExt, Path};
 
     #[tokio::test]
     async fn test_fifo() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -401,7 +401,7 @@ mod tests {
     #[tokio::test]
     #[cfg(all(feature = "http", not(target_arch = "wasm32")))]
     async fn test_url_http() {
-        use crate::client::mock_server::MockServer;
+        use crate::{ObjectStoreExt, client::mock_server::MockServer};
         use http::{Response, header::USER_AGENT};
 
         let server = MockServer::new().await;

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -113,11 +113,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         self.inner.put_multipart_opts(&full_path, opts).await
     }
 
-    async fn get(&self, location: &Path) -> Result<GetResult> {
-        let full_path = self.full_path(location);
-        self.inner.get(&full_path).await
-    }
-
     async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
         let full_path = self.full_path(location);
         self.inner.get_range(&full_path, range).await

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -40,7 +40,7 @@ pub struct ThrottleConfig {
     /// the operation.
     pub wait_delete_per_call: Duration,
 
-    /// Sleep duration for every byte received during [`get`](ThrottledStore::get).
+    /// Sleep duration for every byte received during [`get_opts`](ThrottledStore::get_opts).
     ///
     /// Sleeping is performed after the underlying store returned and only for successful gets. The
     /// sleep duration is additive to [`wait_get_per_call`](Self::wait_get_per_call).
@@ -50,7 +50,7 @@ pub struct ThrottleConfig {
     /// resulting sleep time will be partial as well.
     pub wait_get_per_byte: Duration,
 
-    /// Sleep duration for every call to [`get`](ThrottledStore::get).
+    /// Sleep duration for every call to [`get_opts`](ThrottledStore::get_opts).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of
     /// the operation. The sleep duration is additive to
@@ -168,16 +168,6 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
             upload,
             sleep: self.config().wait_put_per_call,
         }))
-    }
-
-    async fn get(&self, location: &Path) -> Result<GetResult> {
-        sleep(self.config().wait_get_per_call).await;
-
-        // need to copy to avoid moving / referencing `self`
-        let wait_get_per_byte = self.config().wait_get_per_byte;
-
-        let result = self.inner.get(location).await?;
-        Ok(throttle_get(result, wait_get_per_byte))
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {


### PR DESCRIPTION
# Which issue does this PR close?
See #385 and #405.

# Rationale for this change
`get` is just `get_opts` with default options.

# What changes are included in this PR?
1. move method to extension trait
2. remove no-longer-required implementations

# Are there any user-facing changes?
**Breaking:** `get` moved from `ObjectStore` to `ObjectStoreExt`.