### PR TITLE
Fix Azure Paths Parsing being broken since 0.12.3 #443

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -307,6 +307,14 @@ mod tests {
                 (ObjectStoreScheme::MicrosoftAzure, "path"),
             ),
             (
+                "abfss://account/container",
+                (ObjectStoreScheme::MicrosoftAzure, ""),
+            ),
+            (
+                "abfss://account/container/path",
+                (ObjectStoreScheme::MicrosoftAzure, "path"),
+            ),
+            (
                 "gs://bucket/path",
                 (ObjectStoreScheme::GoogleCloudStorage, "path"),
             ),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #443


# Rationale for this change
 
Two of the downstream projects, delta-rs and datafusion used the parse function which was changed on #399 
Which has led to those packages being rendered unusable with azure storage accounts since datafusion uses the direct https endpoints.

Delta-rs directly calls parse here:

https://github.com/delta-io/delta-rs/blob/main/crates/azure/src/lib.rs

# What changes are included in this PR?

Modifying/Reverting the strip bucket command along with azurite tests to not make it happen again.
Container name should always be included as its not a bug.

# Are there any user-facing changes?

These might break obstore changed based the changes on #399  like
https://github.com/developmentseed/obstore/issues/477

Would need maintainers and collaborators to comment.