### PR TITLE
refactor!: move `get_range` to `ObjectStoreExt`

### DIFF
--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -19,8 +19,8 @@
 
 use crate::path::Path;
 use crate::{
-    Attributes, Extensions, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions,
-    PutPayloadMut, TagSet, WriteMultipart,
+    Attributes, Extensions, ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions,
+    PutOptions, PutPayloadMut, TagSet, WriteMultipart,
 };
 use bytes::Bytes;
 use futures::future::{BoxFuture, FutureExt};
@@ -37,7 +37,7 @@ pub const DEFAULT_BUFFER_SIZE: usize = 1024 * 1024;
 
 /// An async-buffered reader compatible with the tokio IO traits
 ///
-/// Internally this maintains a buffer of the requested size, and uses [`ObjectStore::get_range`]
+/// Internally this maintains a buffer of the requested size, and uses [`ObjectStoreExt::get_range`]
 /// to populate its internal buffer once depleted. This buffer is cleared on seek.
 ///
 /// Whilst simple, this interface will typically be outperformed by the native [`ObjectStore`]
@@ -46,7 +46,7 @@ pub const DEFAULT_BUFFER_SIZE: usize = 1024 * 1024;
 /// round-trips is critical to throughput.
 ///
 /// Systems looking to sequentially scan a file should instead consider using [`ObjectStoreExt::get`],
-/// or [`ObjectStore::get_opts`], or [`ObjectStore::get_range`] to read a particular range.
+/// or [`ObjectStore::get_opts`], or [`ObjectStoreExt::get_range`] to read a particular range.
 ///
 /// Systems looking to read multiple ranges of a file should instead consider using
 /// [`ObjectStore::get_ranges`], which will optimise the vectored IO.

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -135,13 +135,10 @@ impl ObjectStore for ChunkedStore {
         })
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        self.inner.get_range(location, range).await
-    }
-
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
         self.inner.get_ranges(location, ranges).await
     }
+
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         self.inner.head(location).await
     }

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -100,11 +100,6 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         Ok(permit_get_result(r, permit))
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.get_range(location, range).await
-    }
-
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.get_ranges(location, ranges).await

--- a/src/local.rs
+++ b/src/local.rs
@@ -429,15 +429,6 @@ impl ObjectStore for LocalFileSystem {
         .await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        let path = self.path_to_filesystem(location)?;
-        maybe_spawn_blocking(move || {
-            let (mut file, _) = open_file(&path)?;
-            read_range(&mut file, &path, range)
-        })
-        .await
-    }
-
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
         let path = self.path_to_filesystem(location)?;
         let ranges = ranges.to_vec();

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -114,11 +114,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         self.inner.put_multipart_opts(&full_path, opts).await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        let full_path = self.full_path(location);
-        self.inner.get_range(&full_path, range).await
-    }
-
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let full_path = self.full_path(location);
         self.inner.get_opts(&full_path, options).await

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -181,17 +181,6 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         Ok(throttle_get(result, wait_get_per_byte))
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        let config = self.config();
-
-        let sleep_duration =
-            config.wait_get_per_call + config.wait_get_per_byte * (range.end - range.start) as u32;
-
-        sleep(sleep_duration).await;
-
-        self.inner.get_range(location, range).await
-    }
-
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
         let config = self.config();
 


### PR DESCRIPTION
# Which issue does this PR close?
See #385 and #405.

# Rationale for this change
`get_range` is just `get_opts` + `bytes()`.

# What changes are included in this PR?
1. move method to extension trait
2. remove no-longer-required implementations

# Are there any user-facing changes?
**Breaking:** `get_range` moved from `ObjectStore` to `ObjectStoreExt`.