### PR TITLE
fix: wrappers and default trait methods

### DIFF
--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -61,6 +61,7 @@ impl Display for ChunkedStore {
 }
 
 #[async_trait]
+#[deny(clippy::missing_trait_methods)]
 impl ObjectStore for ChunkedStore {
     async fn put_opts(
         &self,
@@ -138,6 +139,9 @@ impl ObjectStore for ChunkedStore {
         self.inner.get_range(location, range).await
     }
 
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        self.inner.get_ranges(location, ranges).await
+    }
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         self.inner.head(location).await
     }
@@ -173,8 +177,16 @@ impl ObjectStore for ChunkedStore {
         self.inner.copy(from, to).await
     }
 
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename(from, to).await
+    }
+
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
         self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename_if_not_exists(from, to).await
     }
 }
 

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -70,6 +70,7 @@ impl<T: ObjectStore> std::fmt::Display for LimitStore<T> {
 }
 
 #[async_trait]
+#[deny(clippy::missing_trait_methods)]
 impl<T: ObjectStore> ObjectStore for LimitStore<T> {
     async fn put_opts(
         &self,

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -93,6 +93,7 @@ fn strip_meta(prefix: &Path, meta: ObjectMeta) -> ObjectMeta {
 }
 
 #[async_trait::async_trait]
+#[deny(clippy::missing_trait_methods)]
 impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
     async fn put_opts(
         &self,

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -147,6 +147,7 @@ impl<T: ObjectStore> std::fmt::Display for ThrottledStore<T> {
 }
 
 #[async_trait]
+#[deny(clippy::missing_trait_methods)]
 impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
     async fn put_opts(
         &self,


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Document that wrapper SHOULD implement all trait methods. Introduce clippy lint for our builtin wrappers and fix `ChunkedStore`.

# What changes are included in this PR?
- documentation
- fix for `ChunkedStore`

# Are there any user-facing changes?
Better docs.