### PR TITLE
refactor!: move `head` to `ObjectStoreExt`

### DIFF
--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -139,10 +139,6 @@ impl ObjectStore for ChunkedStore {
         self.inner.get_ranges(location, ranges).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.inner.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         self.inner.delete(location).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,12 +834,6 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
         .await
     }
 
-    /// Return the metadata for the specified location
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let options = GetOptions::new().with_head(true);
-        Ok(self.get_opts(location, options).await?.meta)
-    }
-
     /// Delete the object at the specified location.
     async fn delete(&self, location: &Path) -> Result<()>;
 
@@ -1106,10 +1100,6 @@ macro_rules! as_ref_impl {
                 self.as_ref().get_ranges(location, ranges).await
             }
 
-            async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-                self.as_ref().head(location).await
-            }
-
             async fn delete(&self, location: &Path) -> Result<()> {
                 self.as_ref().delete(location).await
             }
@@ -1250,6 +1240,9 @@ pub trait ObjectStoreExt: ObjectStore {
     /// }
     /// ```
     fn get_range(&self, location: &Path, range: Range<u64>) -> impl Future<Output = Result<Bytes>>;
+
+    /// Return the metadata for the specified location
+    fn head(&self, location: &Path) -> impl Future<Output = Result<ObjectMeta>>;
 }
 
 impl<T> ObjectStoreExt for T
@@ -1273,6 +1266,11 @@ where
     async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
         let options = GetOptions::new().with_range(Some(range));
         self.get_opts(location, options).await?.bytes().await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        let options = GetOptions::new().with_head(true);
+        Ok(self.get_opts(location, options).await?.meta)
     }
 }
 

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -105,11 +105,6 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         self.inner.get_ranges(location, ranges).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.delete(location).await

--- a/src/local.rs
+++ b/src/local.rs
@@ -1747,7 +1747,7 @@ mod unix_test {
     use tempfile::TempDir;
 
     use crate::local::LocalFileSystem;
-    use crate::{ObjectStore, ObjectStoreExt, Path};
+    use crate::{ObjectStoreExt, Path};
 
     #[tokio::test]
     async fn test_fifo() {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -294,18 +294,6 @@ impl ObjectStore for InMemory {
             .collect()
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let entry = self.entry(location)?;
-
-        Ok(ObjectMeta {
-            location: location.clone(),
-            last_modified: entry.last_modified,
-            size: entry.data.len() as u64,
-            e_tag: Some(entry.e_tag.to_string()),
-            version: None,
-        })
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         self.storage.write().map.remove(location);
         Ok(())

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -124,12 +124,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         self.inner.get_ranges(&full_path, ranges).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let full_path = self.full_path(location);
-        let meta = self.inner.head(&full_path).await?;
-        Ok(self.strip_meta(meta))
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         let full_path = self.full_path(location);
         self.inner.delete(&full_path).await

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -193,11 +193,6 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         self.inner.get_ranges(location, ranges).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        sleep(self.config().wait_put_per_call).await;
-        self.inner.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         sleep(self.config().wait_delete_per_call).await;
 


### PR DESCRIPTION
# Which issue does this PR close?
- part of  #385 
- part of #405.

# Rationale for this change
`head` is just `get_opts` + `with_head(true)`.

# What changes are included in this PR?
1. move method to extension trait
2. remove no-longer-required implementations

# Are there any user-facing changes?
**Breaking:** `head` moved from `ObjectStore` to `ObjectStoreExt`.