### PR TITLE
Use builder fields instead of env vars for determining credential provider

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -1060,10 +1060,9 @@ impl AmazonS3Builder {
                 (Some(_), None, _) => return Err(Error::MissingSecretAccessKey.into()),
                 (None, None, _) => unreachable!(),
             }
-        } else if let (Ok(token_path), Ok(role_arn)) = (
-            std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE"),
-            std::env::var("AWS_ROLE_ARN"),
-        ) {
+        } else if let (Some(token_path), Some(role_arn)) =
+            (self.web_identity_token_file, self.role_arn)
+        {
             debug!("Using WebIdentity credential provider");
 
             let session_name = self


### PR DESCRIPTION
# Which issue does this PR close?

Closes #538.

# Rationale for this change
 
Setting `web_identity_token_file` and `role_arn` via the config would be ignored as the builder was still only checking the env vars.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Setting the AWS web identity fields via the config builder will no longer be ignored

