### PR TITLE
refactor!: `copy` & `copy_if_not_exists` => `copy_opts`

### DIFF
--- a/src/aws/precondition.rs
+++ b/src/aws/precondition.rs
@@ -19,9 +19,9 @@ use crate::config::Parse;
 
 use itertools::Itertools;
 
-/// Configure how to provide [`ObjectStore::copy_if_not_exists`] for [`AmazonS3`].
+/// Configure how to provide [`CopyMode::Create`] for [`AmazonS3`].
 ///
-/// [`ObjectStore::copy_if_not_exists`]: crate::ObjectStore::copy_if_not_exists
+/// [`CopyMode::Create`]: crate::CopyMode::Create
 /// [`AmazonS3`]: super::AmazonS3
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -29,7 +29,7 @@ pub enum S3CopyIfNotExists {
     /// Some S3-compatible stores, such as Cloudflare R2, support copy if not exists
     /// semantics through custom headers.
     ///
-    /// If set, [`ObjectStore::copy_if_not_exists`] will perform a normal copy operation
+    /// If set, [`CopyMode::Create`] will perform a normal copy operation
     /// with the provided header pair, and expect the store to fail with `412 Precondition Failed`
     /// if the destination file already exists.
     ///
@@ -38,7 +38,7 @@ pub enum S3CopyIfNotExists {
     /// For example `header: cf-copy-destination-if-none-match: *`, would set
     /// the header `cf-copy-destination-if-none-match` to `*`
     ///
-    /// [`ObjectStore::copy_if_not_exists`]: crate::ObjectStore::copy_if_not_exists
+    /// [`CopyMode::Create`]: crate::CopyMode::Create
     Header(String, String),
     /// The same as [`S3CopyIfNotExists::Header`] but allows custom status code checking, for object stores that return values
     /// other than 412.

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -23,8 +23,9 @@
 //!
 //! Unused blocks will automatically be dropped after 7 days.
 use crate::{
-    GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, UploadPart,
+    CopyMode, CopyOptions, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload,
+    ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+    UploadPart,
     multipart::{MultipartStore, PartId},
     path::Path,
     signer::Signer,
@@ -151,12 +152,16 @@ impl ObjectStore for MicrosoftAzure {
         self.client.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy_request(from, to, true).await
-    }
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        let CopyOptions {
+            mode,
+            extensions: _,
+        } = options;
 
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy_request(from, to, false).await
+        match mode {
+            CopyMode::Overwrite => self.client.copy_request(from, to, true).await,
+            CopyMode::Create => self.client.copy_request(from, to, false).await,
+        }
     }
 }
 

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -28,8 +28,8 @@ use futures::stream::BoxStream;
 
 use crate::path::Path;
 use crate::{
-    GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutResult,
+    CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions, PutResult,
 };
 use crate::{PutPayload, Result};
 
@@ -166,16 +166,12 @@ impl ObjectStore for ChunkedStore {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.inner.copy(from, to).await
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.inner.copy_if_not_exists(from, to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -40,6 +40,7 @@ use std::time::Duration;
 use crate::client::CredentialProvider;
 use crate::gcp::credential::GCSAuthorizer;
 use crate::signer::Signer;
+use crate::{CopyMode, CopyOptions};
 use crate::{
     GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, UploadPart, multipart::PartId,
@@ -218,12 +219,16 @@ impl ObjectStore for GoogleCloudStorage {
         self.client.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy_request(from, to, false).await
-    }
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        let CopyOptions {
+            mode,
+            extensions: _,
+        } = options;
 
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy_request(from, to, true).await
+        match mode {
+            CopyMode::Overwrite => self.client.copy_request(from, to, true).await,
+            CopyMode::Create => self.client.copy_request(from, to, false).await,
+        }
     }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -45,9 +45,9 @@ use crate::client::{HttpConnector, http_connector};
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
-    ClientConfigKey, ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
-    RetryConfig,
+    ClientConfigKey, ClientOptions, CopyMode, CopyOptions, GetOptions, GetResult, ListResult,
+    MultipartUpload, ObjectMeta, ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload,
+    PutResult, Result, RetryConfig,
 };
 
 mod client;
@@ -210,12 +210,16 @@ impl ObjectStore for HttpStore {
         })
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy(from, to, true).await
-    }
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        let CopyOptions {
+            mode,
+            extensions: _,
+        } = options;
 
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.client.copy(from, to, false).await
+        match mode {
+            CopyMode::Overwrite => self.client.copy(from, to, true).await,
+            CopyMode::Create => self.client.copy(from, to, false).await,
+        }
     }
 }
 

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -18,9 +18,9 @@
 //! An object store that limits the maximum concurrency of the wrapped implementation
 
 use crate::{
-    BoxStream, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, Path, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, StreamExt,
-    UploadPart,
+    BoxStream, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
+    ObjectMeta, ObjectStore, Path, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+    StreamExt, UploadPart,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -151,19 +151,14 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
         let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.copy(from, to).await
+        self.inner.copy_opts(from, to, options).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.copy_if_not_exists(from, to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -22,7 +22,7 @@ use std::ops::Range;
 
 use crate::path::Path;
 use crate::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
 };
 
@@ -182,22 +182,16 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
             })
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
         let full_from = self.full_path(from);
         let full_to = self.full_path(to);
-        self.inner.copy(&full_from, &full_to).await
+        self.inner.copy_opts(&full_from, &full_to, options).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         let full_from = self.full_path(from);
         let full_to = self.full_path(to);
         self.inner.rename(&full_from, &full_to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        let full_from = self.full_path(from);
-        let full_to = self.full_path(to);
-        self.inner.copy_if_not_exists(&full_from, &full_to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -21,7 +21,7 @@ use std::ops::Range;
 use std::{convert::TryInto, sync::Arc};
 
 use crate::multipart::{MultipartStore, PartId};
-use crate::{GetOptions, UploadPart};
+use crate::{CopyOptions, GetOptions, UploadPart};
 use crate::{
     GetResult, GetResultPayload, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, path::Path,
@@ -255,22 +255,16 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         }
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
         sleep(self.config().wait_put_per_call).await;
 
-        self.inner.copy(from, to).await
+        self.inner.copy_opts(from, to, options).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         sleep(self.config().wait_put_per_call).await;
 
         self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        sleep(self.config().wait_put_per_call).await;
-
-        self.inner.copy_if_not_exists(from, to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {

--- a/tests/get_range_file.rs
+++ b/tests/get_range_file.rs
@@ -77,11 +77,7 @@ impl ObjectStore for MyStore {
         todo!()
     }
 
-    async fn copy(&self, _: &Path, _: &Path) -> Result<()> {
-        todo!()
-    }
-
-    async fn copy_if_not_exists(&self, _: &Path, _: &Path) -> Result<()> {
+    async fn copy_opts(&self, _: &Path, _: &Path, _: CopyOptions) -> Result<()> {
         todo!()
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #116.

# Rationale for this change
Change the `ObjectStore` core trait to have a single, extensible copy operation. This helps #385 and #297.

Also adds extensions similar to 
https://github.com/apache/arrow-rs/pull/7170
and
https://github.com/apache/arrow-rs/pull/7213 .

# What changes are included in this PR?
Interface change, see section below.

# Are there any user-facing changes?
- new core method `copy_opts` alongside `CopyOptions` & `CopyMode`
- `copy` & `copy_if_not_exists` are moved to `ObjectStoreExt`
