### PR TITLE
Whitelisting Onelake API & Workspace PL FQDNs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ humantime = "2.1"
 itertools = "0.14.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-regex = { version = "1.11.1", optional = true }
 thiserror = "2.0.2"
 tracing = { version = "0.1" }
 url = "2.2"
@@ -73,7 +72,7 @@ wasm-bindgen-futures = "0.4.18"
 [features]
 default = ["fs"]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded"]
-azure = ["cloud", "httparse", "regex"]
+azure = ["cloud", "httparse"]
 fs = ["walkdir"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud", "md-5"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
1. With the release of the [WS PL FQDNs](https://learn.microsoft.com/en-us/fabric/security/security-workspace-level-private-links-overview#connecting-to-workspaces) with workspace private links, we need to add support for the new workspace FQDNs (“{wsid}.z{xy}.dfs.fabric.microsoft.com), so users can continue to use Delta-RS with OneLake and workspace private links.
2. We have also added support for "-api.onelake" FQDNs. as well [Ref](https://learn.microsoft.com/en-us/fabric/onelake/onelake-access-api#additional-onelake-endpoints).

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
1. Valid WS-PL FQDN egs:
* https://c047b3e34e89407a98d7cf9949ae92a3.zc0.onelake.fabric.microsoft.com
* https://c047b3e34e89407a98d7cf9949ae92a3.zc0.dfs.fabric.microsoft.com
* https://c047b3e34e89407a98d7cf9949ae92a3.zc0.blob.fabric.microsoft.com
3. Invalid WS-PL FQDN egs:
* https://c047b3e34e89407a98d7cf9949ae92a3.z12.blob.fabric.microsoft.com // xy mismatch 
* https://c047b3e34e89407a98d7cf9949ae923.z12.blob.fabric.microsoft.com  // workspaceid 31 chars
5. New API (regional & non-regional) endpoint support
* https://uksouth-api.onelake.fabric.microsoft.com
* https://api.onelake.fabric.microsoft.com

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes. The documentaion is as below:
1. https://learn.microsoft.com/en-us/fabric/security/security-workspace-level-private-links-overview#connecting-to-workspaces
7. https://learn.microsoft.com/en-us/fabric/onelake/onelake-access-api#additional-onelake-endpoints

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
