### PR TITLE
Allow explicitly specifying GCS base URL

### DIFF
--- a/src/gcp/builder.rs
+++ b/src/gcp/builder.rs
@@ -160,7 +160,7 @@ pub enum GoogleConfigKey {
     /// - `bucket`
     /// - `bucket_name`
     Bucket,
-    
+
     /// Base URL
     ///
     /// See [`GoogleCloudStorageBuilder::with_base_url`] for details.
@@ -384,7 +384,7 @@ impl GoogleCloudStorageBuilder {
     }
 
     /// Sets the base URL for communicating with GCS.
-    /// 
+    ///
     /// If not explicitly set, it will be:
     /// 1. Derived from the service account credentials, if provided
     /// 2. Otherwise, uses the default GCS endpoint
@@ -774,14 +774,20 @@ mod tests {
             .with_base_url("https://explicitly-overriden:4443")
             .build()
             .unwrap();
-        assert_eq!(explicit_override.client.config().base_url, "https://explicitly-overriden:4443");
+        assert_eq!(
+            explicit_override.client.config().base_url,
+            "https://explicitly-overriden:4443"
+        );
 
         let url_in_credentials = GoogleCloudStorageBuilder::new()
             .with_bucket_name("foo")
             .with_service_account_key(FAKE_KEY_WITH_BASE_URL)
             .build()
             .unwrap();
-        assert_eq!(url_in_credentials.client.config().base_url, "https://base-url-from-credentials:4443");
+        assert_eq!(
+            url_in_credentials.client.config().base_url,
+            "https://base-url-from-credentials:4443"
+        );
 
         let explicit_override_and_credentials = GoogleCloudStorageBuilder::new()
             .with_bucket_name("foo")
@@ -789,7 +795,10 @@ mod tests {
             .with_service_account_key(FAKE_KEY_WITH_BASE_URL)
             .build()
             .unwrap();
-        assert_eq!(explicit_override_and_credentials.client.config().base_url, "https://explicitly-overriden:4443");
+        assert_eq!(
+            explicit_override_and_credentials.client.config().base_url,
+            "https://explicitly-overriden:4443"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #566

# Rationale for this change
 
Currently, the only way to override the GCS base URL is to provide a service account credentials file that contains a `gcs_base_url`.

If for some reason the user cannot provide such a file (because they're authenticated a different way), being able to explicitly override the base URL is useful.

This can also be useful while testing locally, against a local implementation of GCS (I'm not personally doing this, but I suppose this is a valid use case)

# What changes are included in this PR?

This PR adds a `.with_base_url()` method on the GCP builder, accompanied with unit tests.

This override takes precedence over the URL from the service account credentials file, but is optional, so this should be strictly compatible with the previous implementation. 

# Are there any user-facing changes?

New `.with_base_url()` on the GCS builder.

No breaking changes.
