### PR TITLE
Remove dev dependency on openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ rand = "0.9"
 tempfile = "3.1.0"
 regex = "1.11.1"
 # The "gzip" feature for reqwest is enabled for an integration test.
-reqwest = { version = "0.12", features = ["gzip"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.50"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #576 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Noticed whilst poking around on #576 

Before

```
cargo tree -i openssl --all-features
openssl v0.10.73
└── native-tls v0.2.14
    ├── hyper-tls v0.6.0
    │   └── reqwest v0.12.15
    │       └── object_store v0.12.4 (/home/raphael/repos/external/arrow-rs-object-store)
    │       [dev-dependencies]
    │       └── object_store v0.12.4 (/home/raphael/repos/external/arrow-rs-object-store)
    ├── reqwest v0.12.15 (*)
    └── tokio-native-tls v0.3.1
        ├── hyper-tls v0.6.0 (*)
        └── reqwest v0.12.15 (*)
```

After

```
$ cargo tree -i openssl --all-features
error: package ID specification `openssl` did not match any package
```

# What changes are included in this PR?



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
