### PR TITLE
correctly expose HttpError through RetryError::source

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -740,8 +740,9 @@ mod tests {
         while let Some(source) = err.source() {
             err = source;
             if let Some(http_err) = err.downcast_ref::<HttpError>() {
-                found = true;
                 assert_eq!(http_err.kind(), HttpErrorKind::Request);
+                found = true;
+                break;
             }
         }
         assert!(found, "HttpError not found in source chain");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #579

# Rationale for this change

Consistently expose HttpError in the source chain for all http errors.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

The issue is caused by `#[error(transparent)]`, which forwards the source method to the underlying error's source impl. The intention is that `transparent` results in the underlying error appearing to be embedded transparently within the embedding error. This means a user can't retrieve the `HttpError` via reflection.

I also added a test to verify that you can retrieve the HttpError in the source chain.


# Are there any user-facing changes?

`source` will start returning HttpError before `reqwest::Error` when executed recursively. Hopefully, users recursively search for errors. This will break users who expect `reqwest::Error` to be at a fixed number of steps below the root error type.
