### PR TITLE
fix: clippy warning `SO_LINGER` w/ zero doesn't block (also: it's just a test)

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -848,6 +848,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(
+        deprecated,
+        reason = "SO_LINGER w/ zero timeout doesn't block, see https://github.com/tokio-rs/tokio/issues/7751#issuecomment-3709831265"
+    )]
     async fn test_connection_reset_is_retried() {
         let retry = RetryConfig {
             backoff: Default::default(),


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
CI failing after latest tokio release.

# What changes are included in this PR?
Accept the deprecation, see https://github.com/tokio-rs/tokio/issues/7751#issuecomment-3709831265

# Are there any user-facing changes?
\-