### PR TITLE
[release/0.12] backport fix: `docs.rs` build failure (#591)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,


### PR DESCRIPTION
- part of https://github.com/apache/arrow-rs-object-store/issues/582

This backports the fix for the docs.rs build to the 0.12 branch
- https://github.com/apache/arrow-rs-object-store/pull/591