### PR TITLE
Fix Azure URL parsing

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -670,13 +670,13 @@ impl MicrosoftAzureBuilder {
                             self.account_name = Some(validate(a)?);
                             self.container_name = Some(validate(parsed.username())?);
                         }
-                        Some((a, "dfs.fabric.microsoft.com")) | Some((a, "blob.fabric.microsoft.net")) => {
+                        Some((a, "dfs.fabric.microsoft.com"))
+                        | Some((a, "blob.fabric.microsoft.net")) => {
                             self.account_name = Some(validate(a)?);
                             self.container_name = Some(validate(parsed.username())?);
                             self.use_fabric_endpoint = true.into();
                         }
-                        _ => return Err(Error::UrlNotRecognised { url: url.into() }.into())
-
+                        _ => return Err(Error::UrlNotRecognised { url: url.into() }.into()),
                     }
                 }
             }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #443

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

https://github.com/apache/arrow-rs-object-store/pull/399 introduced a breaking change to the way that we parse `az://` URLs. This IMO reflects a more sensible URL encoding, but this doesn't match the URL encoding expected by the rest of this crate, which in turn is borrowed from fsspec.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Reverts the URL parsing change in #399

# Are there any user-facing changes?

Technically this is a bug fix, but might make sense to wait for a breaking release.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
