### PR TITLE
Clarify behavior of `parse_url_opts` with regards to case sensitivity 

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -178,7 +178,8 @@ pub fn parse_url(url: &Url) -> Result<(Box<dyn ObjectStore>, Path), super::Error
 ///   Note different object stores accept different configuration options, so
 ///   the options that are read depends on the `url` value. One common pattern
 ///   is to pass configuration information via process variables using
-///   [`std::env::vars`].
+///   [`std::env::vars`]. Keys must be lower-case and match the list of supported
+///   keys to apply successfully.
 ///
 /// Returns
 /// - An [`ObjectStore`] of the corresponding type


### PR DESCRIPTION
# Which issue does this PR close?

Related to #529 

# Rationale for this change

Clarify the behavior of `parse_url_opts`, while the various `from_env()` functions do mention they only support case sensitivity, it does seem like multiple users have tried to use `parse_url_opts` and ended up with pretty confusing problems.

# What changes are included in this PR?

Small enhancement to docs

# Are there any user-facing changes?

No