### PR TITLE
Unblock emulator based tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,17 +136,14 @@ jobs:
           KMS_KEY=$(aws --endpoint-url=http://localhost:4566 kms create-key --description "test key")
           echo "AWS_SSE_KMS_KEY_ID=$(echo $KMS_KEY | jq -r .KeyMetadata.KeyId)" >> $GITHUB_ENV
 
-      - name: Setup UV
-        uses: astral-sh/setup-uv@v7
-
       - name: Configure Azurite (Azure emulation)
         # the magical connection string is from
         # https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio#http-connection-strings
-        # We specify an azure-cli version because 2.82 was released before azurite supported service version 2026-02-06
+        # We skip the API version check to prevent breaks related to differences between Azurite, Azure and the azure-cli, 
         # see https://github.com/Azure/Azurite/issues/2623
         run: |
-          echo "AZURITE_CONTAINER=$(docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite:3.35.0)" >> $GITHUB_ENV
-          uvx --from 'azure-cli==2.81.0' --prerelease=allow az storage container create -n test-bucket --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;'
+          echo "AZURITE_CONTAINER=$(docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite azurite -l /data --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck)" >> $GITHUB_ENV
+          az storage container create -n test-bucket --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;'
 
       - name: Setup Rust toolchain
         run: |


### PR DESCRIPTION
# Which issue does this PR close?

Closes #626.

# Rationale for this change
 
Get CI to green and actually test all emulator based integrations.

# What changes are included in this PR?

Skip API check in azurite to make sure it doesn't break when Azure's tooling causes a difference between Azurite and Azure

# Are there any user-facing changes?

None