### PR TITLE
Use platform specific `read_at` when available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,8 @@
 //!
 //! [`BufReader`]: buffered::BufReader
 //! [`BufWriter`]: buffered::BufWriter
+//! [`Read`]: std::io::Read
+//! [`Seek`]: std::io::Seek
 //!
 //! # Adapters
 //!
@@ -607,8 +609,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{StreamExt, TryStreamExt, stream::BoxStream};
 use std::fmt::{Debug, Formatter};
-#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
-use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -1650,22 +1650,11 @@ impl GetResult {
             #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
             GetResultPayload::File(mut file, path) => {
                 maybe_spawn_blocking(move || {
-                    file.seek(SeekFrom::Start(self.range.start as _))
-                        .map_err(|source| local::Error::Seek {
-                            source,
-                            path: path.clone(),
-                        })?;
+                    use crate::local::read_range;
 
-                    let mut buffer = if let Ok(len) = len.try_into() {
-                        Vec::with_capacity(len)
-                    } else {
-                        Vec::new()
-                    };
-                    file.take(len as _)
-                        .read_to_end(&mut buffer)
-                        .map_err(|source| local::Error::UnableToReadBytes { source, path })?;
+                    let buffer = read_range(&mut file, &path, self.range)?;
 
-                    Ok(buffer.into())
+                    Ok(buffer)
                 })
                 .await
             }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #622.

# Rationale for this change
 
Saves on at least one seek syscall per range

# What changes are included in this PR?

1. On windows and unix, make use of their platform specific `FileExt::read_at` functions.
2. Unifies the read implementation uses in `LocalStore::read_ranges` and for local files in `GetResult::bytes`, so this codepath is shared across both implementation which are currently very similar with one minor change.


# Are there any user-facing changes?

No
