### PR TITLE
fix(azure): correct Microsoft Fabric blob endpoint domain

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -671,7 +671,7 @@ impl MicrosoftAzureBuilder {
                             self.container_name = Some(validate(parsed.username())?);
                         }
                         Some((a, "dfs.fabric.microsoft.com"))
-                        | Some((a, "blob.fabric.microsoft.net")) => {
+                        | Some((a, "blob.fabric.microsoft.com")) => {
                             self.account_name = Some(validate(a)?);
                             self.container_name = Some(validate(parsed.username())?);
                             self.use_fabric_endpoint = true.into();
@@ -1127,6 +1127,14 @@ mod tests {
         let mut builder = MicrosoftAzureBuilder::new();
         builder
             .parse_url("az://container@account.dfs.fabric.microsoft.com/path-part/file")
+            .unwrap();
+        assert_eq!(builder.account_name, Some("account".to_string()));
+        assert_eq!(builder.container_name, Some("container".to_string()));
+        assert!(builder.use_fabric_endpoint.get().unwrap());
+
+        let mut builder = MicrosoftAzureBuilder::new();
+        builder
+            .parse_url("az://container@account.blob.fabric.microsoft.com/path-part/file")
             .unwrap();
         assert_eq!(builder.account_name, Some("account".to_string()));
         assert_eq!(builder.container_name, Some("container".to_string()));


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Fixes a typo in the Azure URL parser where `blob.fabric.microsoft.net` was used instead of the correct `blob.fabric.microsoft.com` domain.

The Microsoft Fabric endpoints use the `.microsoft.com` TLD, not `.microsoft.net`:
- `https://<account>.dfs.fabric.microsoft.com`
- `https://<account>.blob.fabric.microsoft.com`

Reference: https://learn.microsoft.com/en-us/fabric/onelake/onelake-access-api

# What changes are included in this PR?
- Changed `blob.fabric.microsoft.net` → `blob.fabric.microsoft.com` in the `abfs`/`az` URL scheme parsing
- Added test case for `az://container@account.blob.fabric.microsoft.com/` URLs

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes, this is a user-facing bug fix:

- Fixed Azure URL parsing to recognize `blob.fabric.microsoft.com` (was incorrectly `blob.fabric.microsoft.net`)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
