### PR TITLE
Add CRC64NVME checksum support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ walkdir = { version = "2", optional = true }
 
 # Cloud storage support
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
+crc-fast = { version = "1.10" }
 form_urlencoded = { version = "1.2", optional = true }
 http-body-util = { version = "0.1.2", optional = true }
 httparse = { version = "1.8.0", default-features = false, features = ["std"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ walkdir = { version = "2", optional = true }
 
 # Cloud storage support
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
-crc-fast = { version = "1.10" }
+crc-fast = { version = "1.6" , optional = true }
 form_urlencoded = { version = "1.2", optional = true }
 http-body-util = { version = "0.1.2", optional = true }
 httparse = { version = "1.8.0", default-features = false, features = ["std"], optional = true }
@@ -80,7 +80,7 @@ cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream
 azure = ["cloud", "httparse"]
 fs = ["walkdir", "tokio"]
 gcp = ["cloud", "rustls-pki-types"]
-aws = ["cloud", "md-5"]
+aws = ["cloud", "crc-fast", "md-5"]
 http = ["cloud"]
 tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 integration = ["rand", "tokio"]

--- a/src/aws/checksum.rs
+++ b/src/aws/checksum.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 /// Enum representing checksum algorithm supported by S3.
 pub enum Checksum {
     /// SHA-256 algorithm.

--- a/src/aws/checksum.rs
+++ b/src/aws/checksum.rs
@@ -24,12 +24,15 @@ use std::str::FromStr;
 pub enum Checksum {
     /// SHA-256 algorithm.
     SHA256,
+    /// CRC64-NVME algorithm.
+    CRC64NVME,
 }
 
 impl std::fmt::Display for Checksum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             Self::SHA256 => write!(f, "sha256"),
+            Self::CRC64NVME => write!(f, "crc64nvme"),
         }
     }
 }
@@ -40,6 +43,7 @@ impl FromStr for Checksum {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "sha256" => Ok(Self::SHA256),
+            "crc64nvme" => Ok(Self::CRC64NVME),
             _ => Err(()),
         }
     }

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -43,7 +43,6 @@ use async_trait::async_trait;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use bytes::{Buf, Bytes};
-use crc_fast;
 use http::header::{
     CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LENGTH,
     CONTENT_TYPE,

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -43,6 +43,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use bytes::{Buf, Bytes};
+use crc_fast;
 use http::header::{
     CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LENGTH,
     CONTENT_TYPE,
@@ -59,6 +60,7 @@ use std::sync::Arc;
 
 const VERSION_HEADER: &str = "x-amz-version-id";
 const SHA256_CHECKSUM: &str = "x-amz-checksum-sha256";
+const CRC64NVME_CHECKSUM: &str = "x-amz-checksum-crc64nvme";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-amz-meta-";
 const ALGORITHM: &str = "x-amz-checksum-algorithm";
 const STORAGE_CLASS: &str = "x-amz-storage-class";
@@ -398,19 +400,40 @@ impl Request<'_> {
     }
 
     pub(crate) fn with_payload(mut self, payload: PutPayload) -> Self {
-        if (!self.config.skip_signature && self.config.sign_payload)
-            || self.config.checksum.is_some()
-        {
+        let needs_sha256_for_signing = !self.config.skip_signature && self.config.sign_payload;
+        let needs_sha256_for_checksum = matches!(self.config.checksum, Some(Checksum::SHA256));
+
+        let sha256_digest = if needs_sha256_for_signing || needs_sha256_for_checksum {
             let mut sha256 = Context::new(&digest::SHA256);
             payload.iter().for_each(|x| sha256.update(x));
-            let payload_sha256 = sha256.finish();
+            Some(sha256.finish())
+        } else {
+            None
+        };
 
-            if let Some(Checksum::SHA256) = self.config.checksum {
-                self.builder = self
-                    .builder
-                    .header(SHA256_CHECKSUM, BASE64_STANDARD.encode(payload_sha256));
+        if needs_sha256_for_signing {
+            self.payload_sha256 = sha256_digest;
+        }
+
+        match self.config.checksum {
+            Some(Checksum::SHA256) => {
+                self.builder = self.builder.header(
+                    SHA256_CHECKSUM,
+                    BASE64_STANDARD.encode(sha256_digest.unwrap()),
+                );
             }
-            self.payload_sha256 = Some(payload_sha256);
+            Some(Checksum::CRC64NVME) => {
+                let crc_algo = crc_fast::CrcAlgorithm::Crc64Nvme;
+                let mut digest = crc_fast::Digest::new(crc_algo);
+                payload.iter().for_each(|x| digest.update(x));
+                let checksum = digest.finalize();
+
+                self.builder = self.builder.header(
+                    CRC64NVME_CHECKSUM,
+                    BASE64_STANDARD.encode(checksum.to_be_bytes()),
+                )
+            }
+            None => {}
         }
 
         let content_length = payload.content_length();
@@ -658,6 +681,9 @@ impl S3Client {
                 Checksum::SHA256 => {
                     request = request.header(ALGORITHM, "SHA256");
                 }
+                Checksum::CRC64NVME => {
+                    request = request.header(ALGORITHM, "CRC64NVME");
+                }
             }
         }
         let response = request
@@ -715,14 +741,18 @@ impl S3Client {
         }
 
         let (parts, body) = request.send().await?.into_parts();
-        let (e_tag, checksum_sha256) = if is_copy {
+        let (e_tag, checksum_sha256, checksum_crc64nvme) = if is_copy {
             let response = body
                 .bytes()
                 .await
                 .map_err(|source| Error::CreateMultipartResponseBody { source })?;
             let response: CopyPartResult = quick_xml::de::from_reader(response.reader())
                 .map_err(|source| Error::InvalidMultipartResponse { source })?;
-            (response.e_tag, response.checksum_sha256)
+            (
+                response.e_tag,
+                response.checksum_sha256,
+                response.checksum_crc64nvme,
+            )
         } else {
             let e_tag = get_etag(&parts.headers).map_err(|source| Error::Metadata { source })?;
             let checksum_sha256 = parts
@@ -730,15 +760,33 @@ impl S3Client {
                 .get(SHA256_CHECKSUM)
                 .and_then(|v| v.to_str().ok())
                 .map(|v| v.to_string());
-            (e_tag, checksum_sha256)
+            let checksum_crc64nvme = parts
+                .headers
+                .get(CRC64NVME_CHECKSUM)
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v.to_string());
+            (e_tag, checksum_sha256, checksum_crc64nvme)
         };
 
-        let content_id = if self.config.checksum == Some(Checksum::SHA256) {
-            let meta = PartMetadata {
-                e_tag,
-                checksum_sha256,
-            };
-            quick_xml::se::to_string(&meta).unwrap()
+        let content_id = if let Some(checksum) = self.config.checksum {
+            match checksum {
+                Checksum::SHA256 => {
+                    let meta = PartMetadata {
+                        e_tag,
+                        checksum_sha256,
+                        checksum_crc64nvme: None,
+                    };
+                    quick_xml::se::to_string(&meta).unwrap()
+                }
+                Checksum::CRC64NVME => {
+                    let meta = PartMetadata {
+                        e_tag,
+                        checksum_sha256: None,
+                        checksum_crc64nvme,
+                    };
+                    quick_xml::se::to_string(&meta).unwrap()
+                }
+            }
         } else {
             e_tag
         };

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -765,27 +765,16 @@ impl S3Client {
             (e_tag, checksum_sha256, checksum_crc64nvme)
         };
 
-        let content_id = if let Some(checksum) = self.config.checksum {
-            match checksum {
-                Checksum::SHA256 => {
-                    let meta = PartMetadata {
-                        e_tag,
-                        checksum_sha256,
-                        checksum_crc64nvme: None,
-                    };
-                    quick_xml::se::to_string(&meta).unwrap()
-                }
-                Checksum::CRC64NVME => {
-                    let meta = PartMetadata {
-                        e_tag,
-                        checksum_sha256: None,
-                        checksum_crc64nvme,
-                    };
-                    quick_xml::se::to_string(&meta).unwrap()
-                }
+        let content_id = match self.config.checksum {
+            Some(_) => {
+                let meta = PartMetadata {
+                    e_tag,
+                    checksum_sha256,
+                    checksum_crc64nvme,
+                };
+                quick_xml::se::to_string(&meta).unwrap()
             }
-        } else {
-            e_tag
+            None => e_tag,
         };
 
         Ok(PartId { content_id })

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -592,7 +592,6 @@ mod tests {
         maybe_skip_integration!();
 
         let bucket = "test-bucket-for-copy-if-not-exists";
-        let bucket = "kdn-bkt1"; //kdn
         let checksum_src = Checksum::SHA256;
         let checksum_dst = Checksum::CRC64NVME;
 

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -595,8 +595,8 @@ mod tests {
         let checksum_src = Checksum::SHA256;
         let checksum_dst = Checksum::CRC64NVME;
 
-        let src = Path::parse("src.bin").unwrap();
-        let dst = Path::parse("dst.bin").unwrap();
+        let src = Path::parse("change_checksum_src.bin").unwrap();
+        let dst = Path::parse("change_checksum_dst.bin").unwrap();
 
         let store = AmazonS3Builder::from_env()
             .with_bucket_name(bucket)

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -531,30 +531,32 @@ mod tests {
         maybe_skip_integration!();
 
         let bucket = "test-bucket-for-checksum";
-        let store = AmazonS3Builder::from_env()
-            .with_bucket_name(bucket)
-            .with_checksum_algorithm(Checksum::SHA256)
-            .build()
-            .unwrap();
+        for checksum in [Checksum::SHA256, Checksum::CRC64NVME] {
+            let store = AmazonS3Builder::from_env()
+                .with_bucket_name(bucket)
+                .with_checksum_algorithm(checksum)
+                .build()
+                .unwrap();
 
-        let str = "test.bin";
-        let path = Path::parse(str).unwrap();
-        let opts = PutMultipartOptions::default();
-        let mut upload = store.put_multipart_opts(&path, opts).await.unwrap();
+            let str = "test.bin";
+            let path = Path::parse(str).unwrap();
+            let opts = PutMultipartOptions::default();
+            let mut upload = store.put_multipart_opts(&path, opts).await.unwrap();
 
-        upload
-            .put_part(PutPayload::from(vec![0u8; 10_000_000]))
-            .await
-            .unwrap();
-        upload
-            .put_part(PutPayload::from(vec![0u8; 5_000_000]))
-            .await
-            .unwrap();
+            upload
+                .put_part(PutPayload::from(vec![0u8; 10_000_000]))
+                .await
+                .unwrap();
+            upload
+                .put_part(PutPayload::from(vec![0u8; 5_000_000]))
+                .await
+                .unwrap();
 
-        let res = upload.complete().await.unwrap();
-        assert!(res.e_tag.is_some(), "Should have valid etag");
+            let res = upload.complete().await.unwrap();
+            assert!(res.e_tag.is_some(), "Should have valid etag");
 
-        store.delete(&path).await.unwrap();
+            store.delete(&path).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -587,31 +589,33 @@ mod tests {
     async fn write_multipart_file_with_signature_object_lock() {
         maybe_skip_integration!();
 
-        let bucket = "test-object-lock";
-        let store = AmazonS3Builder::from_env()
-            .with_bucket_name(bucket)
-            .with_checksum_algorithm(Checksum::SHA256)
-            .build()
-            .unwrap();
+        for checksum in [Checksum::SHA256, Checksum::CRC64NVME] {
+            let bucket = "test-object-lock";
+            let store = AmazonS3Builder::from_env()
+                .with_bucket_name(bucket)
+                .with_checksum_algorithm(checksum)
+                .build()
+                .unwrap();
 
-        let str = "test.bin";
-        let path = Path::parse(str).unwrap();
-        let opts = PutMultipartOptions::default();
-        let mut upload = store.put_multipart_opts(&path, opts).await.unwrap();
+            let str = "test.bin";
+            let path = Path::parse(str).unwrap();
+            let opts = PutMultipartOptions::default();
+            let mut upload = store.put_multipart_opts(&path, opts).await.unwrap();
 
-        upload
-            .put_part(PutPayload::from(vec![0u8; 10_000_000]))
-            .await
-            .unwrap();
-        upload
-            .put_part(PutPayload::from(vec![0u8; 5_000_000]))
-            .await
-            .unwrap();
+            upload
+                .put_part(PutPayload::from(vec![0u8; 10_000_000]))
+                .await
+                .unwrap();
+            upload
+                .put_part(PutPayload::from(vec![0u8; 5_000_000]))
+                .await
+                .unwrap();
 
-        let res = upload.complete().await.unwrap();
-        assert!(res.e_tag.is_some(), "Should have valid etag");
+            let res = upload.complete().await.unwrap();
+            assert!(res.e_tag.is_some(), "Should have valid etag");
 
-        store.delete(&path).await.unwrap();
+            store.delete(&path).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -668,6 +672,11 @@ mod tests {
 
         // run integration test with checksum set to sha256
         let builder = AmazonS3Builder::from_env().with_checksum_algorithm(Checksum::SHA256);
+        let integration = builder.build().unwrap();
+        put_get_delete_list(&integration).await;
+
+        // run integration test with checksum set to crc64nvme
+        let builder = AmazonS3Builder::from_env().with_checksum_algorithm(Checksum::CRC64NVME);
         let integration = builder.build().unwrap();
         put_get_delete_list(&integration).await;
     }

--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -100,6 +100,8 @@ pub(crate) struct CopyPartResult {
     pub e_tag: String,
     #[serde(default, rename = "ChecksumSHA256")]
     pub checksum_sha256: Option<String>,
+    #[serde(default, rename = "ChecksumCRC64NVME")]
+    pub checksum_crc64nvme: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -113,6 +115,8 @@ pub(crate) struct PartMetadata {
     pub e_tag: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum_crc64nvme: Option<String>,
 }
 
 impl From<Vec<PartId>> for CompleteMultipartUpload {
@@ -127,12 +131,14 @@ impl From<Vec<PartId>> for CompleteMultipartUpload {
                     Err(_) => PartMetadata {
                         e_tag: part.content_id.clone(),
                         checksum_sha256: None,
+                        checksum_crc64nvme: None,
                     },
                 };
                 MultipartPart {
                     e_tag: md.e_tag,
                     part_number: part_idx + 1,
                     checksum_sha256: md.checksum_sha256,
+                    checksum_crc64nvme: md.checksum_crc64nvme,
                 }
             })
             .collect();
@@ -149,6 +155,9 @@ pub(crate) struct MultipartPart {
     #[serde(rename = "ChecksumSHA256")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum_sha256: Option<String>,
+    #[serde(rename = "ChecksumCRC64NVME")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum_crc64nvme: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #611 

# Rationale for this change
 
Improve (AWS) S3 write performance without compromising object integrity.

# What changes are included in this PR?

Key change is that the `CRC64NVME` checksum algorithm, which is the AWS default checksum algorithm, is added as a supported checksum variant.

The `crc-fast` crate is added for maximum performance.

Implementation note: if more checksum algorithms are to be supported, a minor refactor how checksum variants are handled would be in order.

# Are there any user-facing changes?

The following `storage_options` key-value pair will be honored:
```
    "aws_checksum_algorithm": "CRC64NVME",
```
A typical use case would combine this with
```
    "aws_unsigned_payload": "true",
```

Kindly review, thanks!
