### PR TITLE
chore: upgrade to `rand` 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ httparse = { version = "1.8.0", default-features = false, features = ["std"], op
 hyper = { version = "1.2", default-features = false, optional = true }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
 quick-xml = { version = "0.39.0", features = ["serialize", "overlapped-lists"], optional = true }
-rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
+rand = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"], optional = true }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pki-types = { version = "1.9", default-features = false, features = ["std"], optional = true }
@@ -83,7 +83,7 @@ integration = ["rand"]
 [dev-dependencies] # In alphabetical order
 hyper = { version = "1.2", features = ["server"] }
 hyper-util = "0.1"
-rand = "0.9"
+rand = "0.10"
 tempfile = "3.1.0"
 regex = "1.11.1"
 # The "gzip" feature for reqwest is enabled for an integration test.
@@ -91,6 +91,11 @@ reqwest = { version = "0.12", default-features = false, features = ["gzip"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.50"
+
+[dev-dependencies.getrandom_v04]
+package = "getrandom"
+version = "0.4"
+features = ["wasm_js"]
 
 [dev-dependencies.getrandom_v03]
 package = "getrandom"

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -40,7 +40,7 @@ use http::{
     HeaderName, Method,
     header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, HeaderValue, IF_MATCH, IF_NONE_MATCH},
 };
-use rand::Rng as _;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -34,7 +34,7 @@ use crate::{
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::{StreamExt, TryStreamExt};
-use rand::{Rng, rng};
+use rand::{RngExt, rng};
 use std::collections::HashSet;
 use std::slice;
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -246,7 +246,7 @@ mod tests {
     use futures::FutureExt;
     use parking_lot::Mutex;
     use rand::prelude::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     use crate::ObjectStoreExt;
     use crate::memory::InMemory;

--- a/src/util.rs
+++ b/src/util.rs
@@ -331,7 +331,7 @@ mod tests {
     use crate::Error;
 
     use super::*;
-    use rand::{Rng, rng};
+    use rand::{RngExt, rng};
     use std::ops::Range;
 
     /// Calls coalesce_ranges and validates the returned data is correct


### PR DESCRIPTION
# Which issue does this PR close?
Closes #635.

# Rationale for this change
\-

# What changes are included in this PR?
Dependency upgrade.

# Are there any user-facing changes?
\- (no public API affected)
