### PR TITLE
docs: document the `with_config`  options

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -597,7 +597,18 @@ impl AmazonS3Builder {
         self
     }
 
-    /// Set an option on the builder via a key - value pair.
+    #[doc = concat!(
+      "Set an option by key - value pair\n",
+      "\n",
+      "These are the available options:\n",
+      include_str!("config.md"),
+      "\n",
+      "**TIP:**\n",
+      "below settings are also available under the `aws_` prefix.\n",
+      "This can be useful if you want to have different cloud providers.\n",
+      "\n",
+      include_str!("../client/config.md")
+    )]
     pub fn with_config(mut self, key: AmazonS3ConfigKey, value: impl Into<String>) -> Self {
         match key {
             AmazonS3ConfigKey::AccessKeyId => self.access_key_id = Some(value.into()),

--- a/src/aws/config.md
+++ b/src/aws/config.md
@@ -1,0 +1,64 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+#### AWS specific Authentication & Credentials
+
+| configuration              | description                                                | example                                                   |
+| -------------------------- | ---------------------------------------------------------- | --------------------------------------------------------- |
+| `access_key_id`            | AWS Access Key                                             | `AKIAIOSFODNN7EXAMPLE`                                    |
+| `secret_access_key`        | Secret Access Key                                          | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`                |
+| `session_token`<br>`token` | AWS session token used for temporary credentials           | `IQoJb3JpZ2luX2VjEOr...`                                  |
+| `web_identity_token_file`  | Web identity token file path for AssumeRoleWithWebIdentity | `/var/run/secrets/eks.amazonaws.com/serviceaccount/token` |
+| `role_arn`                 | Role ARN to assume with web identity token                 | `arn:aws:iam::123456789012:role/MyWebIdentityRole`        |
+| `role_session_name`        | Session name for web identity assumption                   | `my-session`                                              |
+| `endpoint_url_sts`         | Custom STS endpoint for web identity token exchange        | `https://sts.amazonaws.com`                               |
+
+#### AWS specific Connection & Endpoint Configuration
+
+| configuration                        | description                                                                                                                                                                                                                                                  | example                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `region`                             | AWS region<br>Defaults to `us-east-1`                                                                                                                                                                                                                        | `us-west-2`                                               |
+| `bucket`<br>`bucket_name`            | Bucket name                                                                                                                                                                                                                                                  | `my-app-bucket`                                           |
+| `endpoint`<br>`endpoint_url`         | Custom S3 endpoint<br>Defaults to regional endpoint<br>Ensure consistency with `virtual_hosted_style_request`<br>By default, **only HTTPS schemes are enabled**; enabling HTTP can expose sensitive data<br>Local testing example: `"http://localhost:4566"` | `https://s3.us-west-2.amazonaws.com`                      |
+| `metadata_endpoint`                  | Instance metadata endpoint (IPv4 default `http://169.254.169.254`)<br>IPv6 alternative: `http://fd00:ec2::254`                                                                                                                                               | `http://169.254.169.254`                                  |
+| `container_credentials_relative_uri` | ECS container credentials relative URI                                                                                                                                                                                                                       | `/v2/credentials/12345678-1234-1234-1234-123456789012`    |
+| `container_credentials_full_uri`     | EKS container credentials full URI                                                                                                                                                                                                                           | `http://169.254.170.2/v2/credentials/abc123`              |
+| `container_authorization_token_file` | Authorization token file for EKS container creds                                                                                                                                                                                                             | `/var/run/secrets/eks.amazonaws.com/serviceaccount/token` |
+
+#### AWS specific Request Behavior & Fallbacks
+
+| configuration                  | description                                                                                                                                                                                                                                                                                                                                                                       | example |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `imdsv1_fallback`              | Fall back to IMDSv1 if IMDSv2 is **not supported** (useful for older kube2iam deployments)<br>**Security note:** AWS recommends IMDSv2 only; IMDSv1 is vulnerable to [SSRF attacks](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/)<br>Has no effect if not using instance credentials | `true`  |
+| `virtual_hosted_style_request` | Use virtual-hosted-style requests instead of path-style<br>Endpoint must match the style<br>Ensures correct bucket addressing for security and routing                                                                                                                                                                                                                            | `true`  |
+| `skip_signature`               | Skip signing request<br>**Security warning:** Unsigned requests may expose credentials or allow tampering if endpoint is public                                                                                                                                                                                                                                                   | `true`  |
+| `unsigned_payload`             | Use unsigned payload option (`UNSIGNED-PAYLOAD`) instead of signed<br>**Impact:** Checksums for request body are not computed in canonical requests, which can reduce integrity guarantees<br>Default is signed payload with checksum                                                                                                                                             | `true`  |
+| `disable_tagging`              | Disable tagging objects (useful if unsupported by backend)                                                                                                                                                                                                                                                                                                                        | `true`  |
+| `s3_express`                   | Enable S3 Express One Zone                                                                                                                                                                                                                                                                                                                                                        | `true`  |
+| `request_payer`                | Enable S3 Requester Pays                                                                                                                                                                                                                                                                                                                                                          | `true`  |
+
+#### AWS Specific Object Integrity & Encryption
+
+| configuration             | description                                                                                                         | example                                                      |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `checksum`                | Checksum algorithm for uploads                                                                                      | `SHA256`                                                     |
+| `server_side_encryption`  | Type of server-side encryption:<br>`AES256` (SSE-S3)<br>`aws:kms` (SSE-KMS)<br>`aws:kms:dsse` (DSSE-KMS)<br>`sse-c` | `AES256`                                                     |
+| `kms_key_id`              | KMS Key ID for SSE-KMS or DSSE-KMS                                                                                  | `arn:aws:kms:us-east-1:123456789012:key/abcd-1234-efgh-5678` |
+| `bucket_key_enabled`      | Use bucket’s default KMS key (`true`/`false`)                                                                       | `true`                                                       |
+| `customer_encryption_key` | Base64-encoded 256-bit key for SSE-C                                                                                | `MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=`               |

--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -561,7 +561,18 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Set an option on the builder via a key - value pair.
+    #[doc = concat!(
+      "Set an option by key - value pair\n",
+      "\n",
+      "These are the available options:\n",
+      include_str!("config.md"),
+      "\n",
+      "**TIP:**\n",
+      "below settings are also available under the `aws_` prefix.\n",
+      "This can be useful if you want to have different cloud providers.\n",
+      "\n",
+      include_str!("../client/config.md")
+    )]
     pub fn with_config(mut self, key: AzureConfigKey, value: impl Into<String>) -> Self {
         match key {
             AzureConfigKey::AccessKey => self.access_key = Some(value.into()),

--- a/src/azure/config.md
+++ b/src/azure/config.md
@@ -1,0 +1,57 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+#### Azure specific Authentication & Credentials
+
+| configuration                                 | description                                                                                                                                                | example                                                                                                                                                     |
+|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `account_name`                                | Name of the Azure Storage account                                                                                                                          | `myaccount`                                                                                                                                                 |
+| `access_key`<br>`account_key`<br>`master_key` | Master key for accessing the storage account<br><br>**Security note:**<br> Keep this key secret; anyone with access can read/write all data in the account | `abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef9012`                                                                                          |
+| `client_id`                                   | Service principal client ID for OAuth authorization                                                                                                        | `12345678-90ab-cdef-1234-567890abcdef`                                                                                                                      |
+| `client_secret`                               | Service principal client secret for OAuth authorization<br>**Security note:** Must be kept confidential                                                    | `s3cr3tV@lu3!`                                                                                                                                              |
+| `tenant_id`<br>`authority_id`                 | Tenant ID used in OAuth flows                                                                                                                              | `abcdef12-3456-7890-abcd-ef1234567890`                                                                                                                      |
+| `authority_host`                              | Authority host used in OAuth flows                                                                                                                         | `https://login.microsoftonline.com/`                                                                                                                        |
+| `sas_key`<br>`sas_token`                      | Shared Access Signature (percent-encoded)<br><br>**Security note:**<br> Grants scoped access; treat as sensitive credentials                               | `sv=2021-06-08&ss=b&srt=sco&sp=rwdl`<br>`&se=2025-12-31T23:59:00Z&sig=ABCDEF1234567890`                                                                     |
+| `bearer_token`<br>`token`                     | Bearer token for requests<br><br>**Security note:**<br> Token must be protected; use HTTPS                                                                 | `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`                                                                                                   |
+| `identity_endpoint`<br>`msi_endpoint`         | Endpoint to request a managed identity token                                                                                                               | `http://169.254.169.254/metadata/identity/oauth2/token`                                                                                                     |
+| `object_id`                                   | Object ID for use with managed identity authentication                                                                                                     | `12345678-90ab-cdef-1234-567890abcdef`                                                                                                                      |
+| `msi_resource_id`                             | Resource ID for managed identity authentication                                                                                                            | `/subscriptions/12345678-90ab-cdef-1234-567890abcdef/`<br>`resourcegroups/myrg/providers/Microsoft.ManagedIdentity/`<br>`userAssignedIdentities/myidentity` |
+| `federated_token_file`                        | File containing token for Azure AD workload identity federation                                                                                            | `/var/run/secrets/azure/federated-token`                                                                                                                    |
+| `use_azure_cli`                               | Use Azure CLI for acquiring access token                                                                                                                   | `true`                                                                                                                                                      |
+
+
+#### Azure specific Connection & Endpoint Configuration
+
+| configuration                                 | description                                                  | example                                   |
+|-----------------------------------------------|--------------------------------------------------------------|-------------------------------------------|
+| `endpoint`                                    | Override endpoint used to communicate with blob storage      | `https://myaccount.blob.core.windows.net` |
+| `object_store_use_emulator`<br>`use_emulator` | Use Azurite storage emulator                                 | `true`                                    |
+| `use_fabric_endpoint`                         | Use Azure Fabric endpoint (account.dfs.fabric.microsoft.com) | `true`                                    |
+| `container_name`                              | Container name in the storage account                        | `mycontainer`                             |
+
+#### Azure specific Request Behavior & Security Options
+
+| configuration               | description                                                                                                                                                     | example                                   |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| `skip_signature`            | Skip signing requests<br><br>**Security warning:**<br> Unsigned requests may expose sensitive data or allow tampering; use only in secure or local environments | `true`                                    |
+| `disable_tagging`           | Disable object tagging (useful if backend does not support it)                                                                                                  | `true`                                    |
+| `fabric_token_service_url`  | URL of Fabric token service                                                                                                                                     | `https://fabric-token.mycompany.com`      |
+| `fabric_workload_host`      | Host for Fabric workload                                                                                                                                        | `https://workload.fabric.mycompany.com`   |
+| `fabric_session_token`      | Session token for Fabric<br><br>**Security note:** Must be protected; use HTTPS                                                                                 | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
+| `fabric_cluster_identifier` | Identifier for Fabric cluster                                                                                                                                   | `fabric-cluster-01`                       |

--- a/src/client/config.md
+++ b/src/client/config.md
@@ -1,0 +1,52 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+#### Security options
+
+| configuration                | description                                                                                                                                                                                                                                                                                                                                                    | example |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `allow_http`                 | Allow non-TLS, i.e. non-HTTPS connections<br><br>**Security warning:**<br>If you enable this option, attackers may be able to read the data you request                                                                                                                                                                                                                        | `true`  |
+| `allow_invalid_certificates` | Skip certificate validation on https connections<br><br>**Security warning:**<br>You should think very carefully before using this method. If invalid certificates are trusted, any certificate for any site will be trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort or for testing | `true`  |
+
+
+#### Connection options
+
+| configuration                 | description                                                                                                        | example        |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------|----------------|
+| `user_agent`                  | User-Agent header to be used by this client                                                                        | `martin 1.0.0` |
+| `randomize_addresses`         | Randomize order addresses that the DNS resolution yields.<br>This will spread the connections across more servers. | `true`         |
+| `connect_timeout`             | Timeout for only the connect phase of a Client                                                                     | `5s`           |
+| `timeout`                     | The timeout is applied from when the request starts connecting until the response body has finished                | `10s`          |
+| `pool_idle_timeout`           | The pool max idle timeout                                                                                          | `5m`           |
+| `pool_max_idle_per_host`      | maximum number of idle connections per host                                                                        | `10`           |
+| `http1_only`                  | Only use http1 connections                                                                                         | `false`        |
+| `http2_only`                  | Only use http2 connections                                                                                         | `false`        |
+| `http2_keep_alive_interval`   | Interval for HTTP2 Ping frames should be sent to keep a connection alive.                                          | `15s`          |
+| `http2_keep_alive_timeout`    | Timeout for receiving an acknowledgement of the keep-alive ping.                                                   | `15s`          |
+| `http2_keep_alive_while_idle` | Enable HTTP2 keep alive pings for idle connections                                                                 | `true`         |
+| `http2_max_frame_size`        | Sets the maximum frame size to use for HTTP2.                                                                      |                |
+
+
+#### Proxy settings
+
+| configuration          | description                                        | example                         |
+|------------------------|----------------------------------------------------|---------------------------------|
+| `proxy_url`            | HTTP proxy to use for requests                     | `http://proxy.example.com:8080` |
+| `proxy_ca_certificate` | PEM-formatted CA certificate for proxy connections | `-----BEGIN CERTIFICATE-----`<br>...<br>`-----END CERTIFICATE-----`                              |
+| `proxy_excludes`       | List of hosts that bypass proxy                    | `example.com`, `apache.org`                   |

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -371,7 +371,12 @@ impl ClientOptions {
         Default::default()
     }
 
-    /// Set an option by key
+    #[doc = concat!(
+      "Set an option by key - value pair\n",
+      "\n",
+      "These are the available options:\n",
+      include_str!("../client/config.md")
+    )]
     pub fn with_config(mut self, key: ClientConfigKey, value: impl Into<String>) -> Self {
         match key {
             ClientConfigKey::AllowHttp => self.allow_http.parse(value),

--- a/src/gcp/builder.rs
+++ b/src/gcp/builder.rs
@@ -312,7 +312,18 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
-    /// Set an option on the builder via a key - value pair.
+    #[doc = concat!(
+      "Set an option by key - value pair\n",
+      "\n",
+      "These are the available options:\n",
+      include_str!("config.md"),
+      "\n",
+      "**TIP:**\n",
+      "below settings are also available under the `aws_` prefix.\n",
+      "This can be useful if you want to have different cloud providers.\n",
+      "\n",
+      include_str!("../client/config.md")
+    )]
     pub fn with_config(mut self, key: GoogleConfigKey, value: impl Into<String>) -> Self {
         match key {
             GoogleConfigKey::ServiceAccount => self.service_account_path = Some(value.into()),

--- a/src/gcp/config.md
+++ b/src/gcp/config.md
@@ -1,0 +1,29 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+#### Google specific configuration
+
+| configuration                               | description                                                                                                                                                                                        | example                                                                                                                   |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `base_url`                                  | Sets the base URL for communicating with GCS.<br>If not explicitly set, it will be:<br>1. Derived from the service account credentials, if provided<br>2. Otherwise, uses the default GCS endpoint | `https://storage.googleapis.com`                                                                                          |
+| `service_account`<br>`service_account_path` | Path to the service account file                                                                                                                                                                   | `some/path/to/file`                                                                                                       |
+| `service_account_key`                       | The serialized service account key                                                                                                                                                                 | `{"private_key": "private_key", "private_key_id": "private_key_id", "client_email":"client_email", "disable_oauth":true}` |
+| `bucket`<br>`bucket_name`                   | Bucket name                                                                                                                                                                                        | `foobar-abc`                                                                                                              |
+| `application_credentials`                   | Set the path to the [application credentials file](https://cloud.google.com/docs/authentication/provide-credentials-adc)                                                                           | `some/path/to/file`                                                                                                       |
+| `skip_signature`                            | Skip signing request                                                                                                                                                                               | `true`                                                                                                                    |

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -252,7 +252,12 @@ impl HttpBuilder {
         self
     }
 
-    /// Set individual client configuration without overriding the entire config
+    #[doc = concat!(
+      "Set individual client configuration without overriding the entire config\n",
+      "\n",
+      "These are the available options:\n",
+      include_str!("../client/config.md")
+    )]
     pub fn with_config(mut self, key: ClientConfigKey, value: impl Into<String>) -> Self {
         self.client_options = self.client_options.with_config(key, value);
         self


### PR DESCRIPTION
# Which issue does this PR close?

This PR works towards https://github.com/apache/arrow-rs-object-store/issues/507

# Rationale for this change
 
Currently, a user would not quite know what options exist 

# What changes are included in this PR?

All `with_config` APIs get documentation rewritten.
Due to the amount of documentation required to properly document what this does, I chose markdown.

This has the advantage that dependent projects know what the configuration is and can semi-reli on this. I think everyone wins via this.

I will maintain these docs (I currently already do, but out of tree).
These docs beign in the tree would be more helpfull I assume.

# Are there any user-facing changes?

It is a docs-only change 😉

<img width="1841" height="885" alt="image" src="https://github.com/user-attachments/assets/47287f86-e1f9-406b-b9e1-a7f429b670d8" />