### PR TITLE
fix(azure): fix integer overflow in Fabric token expiry check

### DIFF
--- a/src/azure/credential.rs
+++ b/src/azure/credential.rs
@@ -1252,7 +1252,7 @@ mod tests {
             fabric_workload_host: "fake".to_string(),
             fabric_session_token: "session-token".to_string(),
             fabric_cluster_identifier: "cluster-id".to_string(),
-            storage_access_token: Some(expired_token.clone()),
+            storage_access_token: Some(expired_token),
             token_expiry: Some(expired_timestamp),
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #640.

# Rationale for this change
 
`FabricTokenOAuthProvider::fetch_token` uses unsigned integer subtraction when checking token expiry. When a cached token has expired (`expiry < current_timestamp`), this causes an overflow when adding duration to instant. This prevents the provider from falling through to the token refresh path as intended.

The issue contains a more detailed breakdown.

# What changes are included in this PR?

Replace `-` with `saturating_sub()` for unsigned integer subtractions in the token expiry checks.

Add a repro test that now passes.

# Are there any user-facing changes?

Bug fix only.
