### PR TITLE
Introduce a "tokio" to allow pulling a trait-only build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ itertools = "0.14.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 thiserror = "2.0.2"
-tracing = { version = "0.1" }
 url = "2.2"
 walkdir = { version = "2", optional = true }
 
@@ -60,7 +59,10 @@ rustls-pki-types = { version = "1.9", default-features = false, features = ["std
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"] }
+
+# Optional tokio feature
+tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"], optional = true }
+tracing = { version = "0.1", optional = true }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.31.1", features = ["fs"] }
@@ -71,14 +73,15 @@ wasm-bindgen-futures = "0.4.18"
 
 [features]
 default = ["fs"]
-cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded"]
+cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded", "tokio"]
 azure = ["cloud", "httparse"]
-fs = ["walkdir"]
+fs = ["walkdir", "tokio"]
 gcp = ["cloud", "rustls-pki-types"]
 aws = ["cloud", "md-5"]
 http = ["cloud"]
 tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
-integration = ["rand"]
+integration = ["rand", "tokio"]
+tokio = ["dep:tokio", "dep:tracing"]
 
 [dev-dependencies] # In alphabetical order
 hyper = { version = "1.2", features = ["server"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,6 +541,7 @@
 pub mod aws;
 #[cfg(feature = "azure")]
 pub mod azure;
+#[cfg(feature = "tokio")]
 pub mod buffered;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod chunked;
@@ -549,6 +550,7 @@ pub mod delimited;
 pub mod gcp;
 #[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "tokio")]
 pub mod limit;
 #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 pub mod local;
@@ -558,6 +560,7 @@ pub mod prefix;
 pub mod registry;
 #[cfg(feature = "cloud")]
 pub mod signer;
+#[cfg(feature = "tokio")]
 pub mod throttle;
 
 #[cfg(feature = "cloud")]
@@ -2039,6 +2042,7 @@ pub enum Error {
     },
 
     /// Error when `tokio::spawn` failed
+    #[cfg(feature = "tokio")]
     #[error("Error joining spawned task: {}", source)]
     JoinError {
         /// The wrapped error


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
This change allows users to pull a trait-only build that doesn't require tokio, keeping it very lightweight (its one of the top 3 slowest dependencies to build when building without default features, next to `syn` and `futures-util`).

I've also considered making the `http` dependency optional, and I think it might be possible to make `url` optional too, but I'm not sure what's the desired balance here and figured its worth getting some feedback first. 

Running `cargo tree -e normal --no-default-features` on this branch shows:
```
object_store v0.13.1 (/Users/adamgs/code/object-store)
object_store v0.13.1 (/Users/adamgs/code/object-store)
├── async-trait v0.1.89 (proc-macro)
│   ├── proc-macro2 v1.0.105
│   │   └── unicode-ident v1.0.22
│   ├── quote v1.0.43
│   │   └── proc-macro2 v1.0.105 (*)
│   └── syn v2.0.114
│       ├── proc-macro2 v1.0.105 (*)
│       ├── quote v1.0.43 (*)
│       └── unicode-ident v1.0.22
├── bytes v1.11.0
├── chrono v0.4.43
│   ├── iana-time-zone v0.1.64
│   │   └── core-foundation-sys v0.8.7
│   └── num-traits v0.2.19
├── futures v0.3.31
│   ├── futures-channel v0.3.31
│   │   ├── futures-core v0.3.31
│   │   └── futures-sink v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-executor v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-task v0.3.31
│   │   └── futures-util v0.3.31
│   │       ├── futures-channel v0.3.31 (*)
│   │       ├── futures-core v0.3.31
│   │       ├── futures-io v0.3.31
│   │       ├── futures-macro v0.3.31 (proc-macro)
│   │       │   ├── proc-macro2 v1.0.105 (*)
│   │       │   ├── quote v1.0.43 (*)
│   │       │   └── syn v2.0.114 (*)
│   │       ├── futures-sink v0.3.31
│   │       ├── futures-task v0.3.31
│   │       ├── memchr v2.7.6
│   │       ├── pin-project-lite v0.2.16
│   │       ├── pin-utils v0.1.0
│   │       └── slab v0.4.11
│   ├── futures-io v0.3.31
│   ├── futures-sink v0.3.31
│   ├── futures-task v0.3.31
│   └── futures-util v0.3.31 (*)
├── http v1.4.0
│   ├── bytes v1.11.0
│   └── itoa v1.0.17
├── humantime v2.3.0
├── itertools v0.14.0
│   └── either v1.15.0
├── parking_lot v0.12.5
│   ├── lock_api v0.4.14
│   │   └── scopeguard v1.2.0
│   └── parking_lot_core v0.9.12
│       ├── cfg-if v1.0.4
│       ├── libc v0.2.180
│       └── smallvec v1.15.1
├── percent-encoding v2.3.2
├── thiserror v2.0.17
│   └── thiserror-impl v2.0.17 (proc-macro)
│       ├── proc-macro2 v1.0.105 (*)
│       ├── quote v1.0.43 (*)
│       └── syn v2.0.114 (*)
└── url v2.5.8
    ├── form_urlencoded v1.2.2
    │   └── percent-encoding v2.3.2
    ├── idna v1.1.0
    │   ├── idna_adapter v1.2.1
    │   │   ├── icu_normalizer v2.1.1
    │   │   │   ├── icu_collections v2.1.1
    │   │   │   │   ├── displaydoc v0.2.5 (proc-macro)
    │   │   │   │   │   ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │   ├── quote v1.0.43 (*)
    │   │   │   │   │   └── syn v2.0.114 (*)
    │   │   │   │   ├── potential_utf v0.1.4
    │   │   │   │   │   └── zerovec v0.11.5
    │   │   │   │   │       ├── yoke v0.8.1
    │   │   │   │   │       │   ├── stable_deref_trait v1.2.1
    │   │   │   │   │       │   ├── yoke-derive v0.8.1 (proc-macro)
    │   │   │   │   │       │   │   ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │   │   ├── quote v1.0.43 (*)
    │   │   │   │   │       │   │   ├── syn v2.0.114 (*)
    │   │   │   │   │       │   │   └── synstructure v0.13.2
    │   │   │   │   │       │   │       ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │   │       ├── quote v1.0.43 (*)
    │   │   │   │   │       │   │       └── syn v2.0.114 (*)
    │   │   │   │   │       │   └── zerofrom v0.1.6
    │   │   │   │   │       │       └── zerofrom-derive v0.1.6 (proc-macro)
    │   │   │   │   │       │           ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │           ├── quote v1.0.43 (*)
    │   │   │   │   │       │           ├── syn v2.0.114 (*)
    │   │   │   │   │       │           └── synstructure v0.13.2 (*)
    │   │   │   │   │       ├── zerofrom v0.1.6 (*)
    │   │   │   │   │       └── zerovec-derive v0.11.2 (proc-macro)
    │   │   │   │   │           ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │           ├── quote v1.0.43 (*)
    │   │   │   │   │           └── syn v2.0.114 (*)
    │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   ├── zerofrom v0.1.6 (*)
    │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   ├── icu_normalizer_data v2.1.1
    │   │   │   ├── icu_provider v2.1.1
    │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   ├── icu_locale_core v2.1.1
    │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   ├── litemap v0.8.1
    │   │   │   │   │   ├── tinystr v0.8.2
    │   │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   │   │   ├── writeable v0.6.2
    │   │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   │   ├── writeable v0.6.2
    │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   ├── zerofrom v0.1.6 (*)
    │   │   │   │   ├── zerotrie v0.2.3
    │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   │   └── zerofrom v0.1.6 (*)
    │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   ├── smallvec v1.15.1
    │   │   │   └── zerovec v0.11.5 (*)
    │   │   └── icu_properties v2.1.2
    │   │       ├── icu_collections v2.1.1 (*)
    │   │       ├── icu_locale_core v2.1.1 (*)
    │   │       ├── icu_properties_data v2.1.2
    │   │       ├── icu_provider v2.1.1 (*)
    │   │       ├── zerotrie v0.2.3 (*)
    │   │       └── zerovec v0.11.5 (*)
    │   ├── smallvec v1.15.1
    │   └── utf8_iter v1.0.4
    └── percent-encoding v2.3.2
```

While currently on `main` it prints:
```
object_store v0.13.1 (/Users/adamgs/code/object-store)
├── async-trait v0.1.89 (proc-macro)
│   ├── proc-macro2 v1.0.105
│   │   └── unicode-ident v1.0.22
│   ├── quote v1.0.43
│   │   └── proc-macro2 v1.0.105 (*)
│   └── syn v2.0.114
│       ├── proc-macro2 v1.0.105 (*)
│       ├── quote v1.0.43 (*)
│       └── unicode-ident v1.0.22
├── bytes v1.11.0
├── chrono v0.4.43
│   ├── iana-time-zone v0.1.64
│   │   └── core-foundation-sys v0.8.7
│   └── num-traits v0.2.19
├── futures v0.3.31
│   ├── futures-channel v0.3.31
│   │   ├── futures-core v0.3.31
│   │   └── futures-sink v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-executor v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-task v0.3.31
│   │   └── futures-util v0.3.31
│   │       ├── futures-channel v0.3.31 (*)
│   │       ├── futures-core v0.3.31
│   │       ├── futures-io v0.3.31
│   │       ├── futures-macro v0.3.31 (proc-macro)
│   │       │   ├── proc-macro2 v1.0.105 (*)
│   │       │   ├── quote v1.0.43 (*)
│   │       │   └── syn v2.0.114 (*)
│   │       ├── futures-sink v0.3.31
│   │       ├── futures-task v0.3.31
│   │       ├── memchr v2.7.6
│   │       ├── pin-project-lite v0.2.16
│   │       ├── pin-utils v0.1.0
│   │       └── slab v0.4.11
│   ├── futures-io v0.3.31
│   ├── futures-sink v0.3.31
│   ├── futures-task v0.3.31
│   └── futures-util v0.3.31 (*)
├── http v1.4.0
│   ├── bytes v1.11.0
│   └── itoa v1.0.17
├── humantime v2.3.0
├── itertools v0.14.0
│   └── either v1.15.0
├── parking_lot v0.12.5
│   ├── lock_api v0.4.14
│   │   └── scopeguard v1.2.0
│   └── parking_lot_core v0.9.12
│       ├── cfg-if v1.0.4
│       ├── libc v0.2.180
│       └── smallvec v1.15.1
├── percent-encoding v2.3.2
├── thiserror v2.0.17
│   └── thiserror-impl v2.0.17 (proc-macro)
│       ├── proc-macro2 v1.0.105 (*)
│       ├── quote v1.0.43 (*)
│       └── syn v2.0.114 (*)
├── tokio v1.49.0
│   ├── bytes v1.11.0
│   ├── pin-project-lite v0.2.16
│   └── tokio-macros v2.6.0 (proc-macro)
│       ├── proc-macro2 v1.0.105 (*)
│       ├── quote v1.0.43 (*)
│       └── syn v2.0.114 (*)
├── tracing v0.1.44
│   ├── pin-project-lite v0.2.16
│   ├── tracing-attributes v0.1.31 (proc-macro)
│   │   ├── proc-macro2 v1.0.105 (*)
│   │   ├── quote v1.0.43 (*)
│   │   └── syn v2.0.114 (*)
│   └── tracing-core v0.1.36
│       └── once_cell v1.21.3
└── url v2.5.8
    ├── form_urlencoded v1.2.2
    │   └── percent-encoding v2.3.2
    ├── idna v1.1.0
    │   ├── idna_adapter v1.2.1
    │   │   ├── icu_normalizer v2.1.1
    │   │   │   ├── icu_collections v2.1.1
    │   │   │   │   ├── displaydoc v0.2.5 (proc-macro)
    │   │   │   │   │   ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │   ├── quote v1.0.43 (*)
    │   │   │   │   │   └── syn v2.0.114 (*)
    │   │   │   │   ├── potential_utf v0.1.4
    │   │   │   │   │   └── zerovec v0.11.5
    │   │   │   │   │       ├── yoke v0.8.1
    │   │   │   │   │       │   ├── stable_deref_trait v1.2.1
    │   │   │   │   │       │   ├── yoke-derive v0.8.1 (proc-macro)
    │   │   │   │   │       │   │   ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │   │   ├── quote v1.0.43 (*)
    │   │   │   │   │       │   │   ├── syn v2.0.114 (*)
    │   │   │   │   │       │   │   └── synstructure v0.13.2
    │   │   │   │   │       │   │       ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │   │       ├── quote v1.0.43 (*)
    │   │   │   │   │       │   │       └── syn v2.0.114 (*)
    │   │   │   │   │       │   └── zerofrom v0.1.6
    │   │   │   │   │       │       └── zerofrom-derive v0.1.6 (proc-macro)
    │   │   │   │   │       │           ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │       │           ├── quote v1.0.43 (*)
    │   │   │   │   │       │           ├── syn v2.0.114 (*)
    │   │   │   │   │       │           └── synstructure v0.13.2 (*)
    │   │   │   │   │       ├── zerofrom v0.1.6 (*)
    │   │   │   │   │       └── zerovec-derive v0.11.2 (proc-macro)
    │   │   │   │   │           ├── proc-macro2 v1.0.105 (*)
    │   │   │   │   │           ├── quote v1.0.43 (*)
    │   │   │   │   │           └── syn v2.0.114 (*)
    │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   ├── zerofrom v0.1.6 (*)
    │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   ├── icu_normalizer_data v2.1.1
    │   │   │   ├── icu_provider v2.1.1
    │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   ├── icu_locale_core v2.1.1
    │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   ├── litemap v0.8.1
    │   │   │   │   │   ├── tinystr v0.8.2
    │   │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   │   │   ├── writeable v0.6.2
    │   │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   │   ├── writeable v0.6.2
    │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   ├── zerofrom v0.1.6 (*)
    │   │   │   │   ├── zerotrie v0.2.3
    │   │   │   │   │   ├── displaydoc v0.2.5 (proc-macro) (*)
    │   │   │   │   │   ├── yoke v0.8.1 (*)
    │   │   │   │   │   └── zerofrom v0.1.6 (*)
    │   │   │   │   └── zerovec v0.11.5 (*)
    │   │   │   ├── smallvec v1.15.1
    │   │   │   └── zerovec v0.11.5 (*)
    │   │   └── icu_properties v2.1.2
    │   │       ├── icu_collections v2.1.1 (*)
    │   │       ├── icu_locale_core v2.1.1 (*)
    │   │       ├── icu_properties_data v2.1.2
    │   │       ├── icu_provider v2.1.1 (*)
    │   │       ├── zerotrie v0.2.3 (*)
    │   │       └── zerovec v0.11.5 (*)
    │   ├── smallvec v1.15.1
    │   └── utf8_iter v1.0.4
    └── percent-encoding v2.3.2

```

# What changes are included in this PR?

Introduces a new "tokio" feature, which is enabled by default through both the "fs" feature and "cloud" feature. The feature pulls in both `tokio` and `tracing`, and enables all provided middlewares (retry, throttling, buffered::*, and `LimitStore`).

# Are there any user-facing changes?
For users pulling the crate without default features, they won't be able to use all the middlewares mentioned above.



