### PR TITLE
Clarify ShuffleResolver doc-comments

### DIFF
--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -29,7 +29,7 @@ pub(crate) struct ShuffleResolver;
 impl Resolve for ShuffleResolver {
     fn resolve(&self, name: Name) -> Resolving {
         Box::pin(async move {
-            // use `JoinSet` to propagate cancelation
+            // use `JoinSet` to propagate cancelation to tasks that haven't started running yet.
             let mut tasks = JoinSet::new();
             tasks.spawn_blocking(move || {
                 let it = (name.as_str(), 0).to_socket_addrs()?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -174,6 +174,14 @@ pub enum ClientConfigKey {
     ///
     /// This will spread the connections across more servers.
     ///
+    /// <div class="warning">
+    ///
+    /// **Warning**
+    ///
+    /// This will override the DNS resolver configured by [`reqwest`].
+    ///
+    /// </div>
+    ///
     /// Supported keys:
     /// - `randomize_addresses`
     RandomizeAddresses,


### PR DESCRIPTION
This commit clarifies the ShuffleResolver doc-comments in two places by adding some additional details.

# Which issue does this PR close?

None, it was recommended to open this PR on discord.

# Rationale for this change
 
Clarifies some of the doc-comments around `ShuffleResolver`.

# What changes are included in this PR?

See description

# Are there any user-facing changes?

No
