### PR TITLE
Implement Clone for local and memory stores

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -197,7 +197,7 @@ impl From<Error> for super::Error {
 /// [`LocalFileSystem::copy_opts`] is implemented using [`std::fs::hard_link`], and therefore
 /// does not support copying across filesystem boundaries.
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LocalFileSystem {
     config: Arc<Config>,
     // if you want to delete empty directories when deleting files

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -78,7 +78,7 @@ impl From<Error> for super::Error {
 
 /// In-memory storage suitable for testing or for opting out of using a cloud
 /// storage provider.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct InMemory {
     storage: SharedStorage,
 }


### PR DESCRIPTION
These stores already use Arc internally and there is little reason not to provide benefit of Clone similar to cloud stores and enable parity with these

# Which issue does this PR close?

Sorry, no issue, it feels rather minor issue.

Cloud based stores provide `Clone` impl which means `InMemory` and `LocalFileSystem` are not good stubbing substitute as they lack `Clone` implementation
Hence this PR adds `Clone` derive which will impose clone-ability requirement on these stores 

# What changes are included in this PR?

Add `Clone` derive on `InMemory` and `LocalFileSystem` stores

# Are there any user-facing changes?

No functional changes except adding `Clone` onto `InMemory` and `LocalFileSystem`
