### PR TITLE
Support --xa-s3 suffix for S3 Express One Zone bucket access points

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -1261,7 +1261,10 @@ impl AmazonS3Builder {
 ///
 /// <https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html>
 fn parse_bucket_az(bucket: &str) -> Option<&str> {
-    Some(bucket.strip_suffix("--x-s3")?.rsplit_once("--")?.1)
+    let base = bucket
+        .strip_suffix("--x-s3")
+        .or_else(|| bucket.strip_suffix("--xa-s3"))?;
+    Some(base.rsplit_once("--")?.1)
 }
 
 /// Encryption configuration options for S3.
@@ -1787,8 +1790,11 @@ mod tests {
         let cases = [
             ("bucket-base-name--usw2-az1--x-s3", Some("usw2-az1")),
             ("bucket-base--name--azid--x-s3", Some("azid")),
+            ("bucket-base-name--use1-az4--xa-s3", Some("use1-az4")),
+            ("bucket-base--name--azid--xa-s3", Some("azid")),
             ("bucket-base-name", None),
             ("bucket-base-name--x-s3", None),
+            ("bucket-base-name--xa-s3", None),
         ];
 
         for (bucket, expected) in cases {


### PR DESCRIPTION
## Summary

AWS has introduced a new `--xa-s3` suffix for S3 Express One Zone directory buckets when used with S3 Access Points (in addition to the existing `--x-s3` suffix). For example: `eks-staging-k3--use1-az4--xa-s3`.

https://aws.amazon.com/about-aws/whats-new/2025/05/amazon-s3-express-one-zone-granular-access-controls-access-points/

Currently `parse_bucket_az` only recognizes `--x-s3`, so calling `.with_s3_express(true)` on a bucket with the `--xa-s3` suffix fails with:

```
Invalid Zone suffix for bucket 'eks-staging-k3--use1-az4--xa-s3'
```

This PR updates `parse_bucket_az` to also strip `--xa-s3`, and adds corresponding test cases.

## Test plan
- Added test cases for `--xa-s3` suffix (with and without AZ) to `test_parse_bucket_az`
- All existing tests continue to pass