### PR TITLE
fix: Strip prefix in PrefixStore::get_opts

### DIFF
--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -117,7 +117,16 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let full_path = self.full_path(location);
-        self.inner.get_opts(&full_path, options).await
+        let slf_prefix = self.prefix.clone();
+        self.inner
+            .get_opts(&full_path, options)
+            .await
+            .map(move |opts| GetResult {
+                payload: opts.payload,
+                range: opts.range,
+                attributes: opts.attributes,
+                meta: strip_meta(&slf_prefix, opts.meta),
+            })
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #664


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Calls strip_meta on the `.meta` field of the `GetResult` from the inner store of the PrefixStore.


# Are there any user-facing changes?

The meta.location coming from PrefixStore::head, get_opts, etc no longer has the prefix. I can't imagine anyone relying on the functionality of this bug. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
