### PR TITLE
feat(local): explicit close with error checking for LocalFileSystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,12 @@ serde_urlencoded = { version = "0.7", optional = true }
 tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"], optional = true }
 tracing = { version = "0.1", optional = true }
 
+[target.'cfg(target_family="unix")'.dependencies]
+nix = { version = "0.31.1", default-features = false, optional = true }
+
+[target.'cfg(target_family="windows")'.dependencies]
+windows-sys = { version = "0.61.2", default-features = false, features = ["Win32_Foundation"], optional = true }
+
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.31.1", features = ["fs"] }
 
@@ -77,7 +83,7 @@ futures-channel = {version = "0.3", features = ["sink"]}
 default = ["fs"]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded", "tokio"]
 azure = ["cloud", "httparse"]
-fs = ["walkdir", "tokio"]
+fs = ["walkdir", "tokio", "nix", "windows-sys"]
 gcp = ["cloud", "rustls-pki-types"]
 aws = ["cloud", "md-5"]
 http = ["cloud"]

--- a/src/local.rs
+++ b/src/local.rs
@@ -137,6 +137,32 @@ impl From<Error> for super::Error {
     }
 }
 
+/// Explicitly close a file, checking for errors that would be silently ignored by Rust's `File::drop()`.
+///
+/// On network filesystems (e.g. NFS), `close()` can fail and indicate data loss.
+fn close_file(file: File) -> std::result::Result<(), io::Error> {
+    #[cfg(target_family = "unix")]
+    {
+        nix::unistd::close(file).map_err(|e| e.into())
+    }
+    #[cfg(target_family = "windows")]
+    {
+        use std::os::windows::io::IntoRawHandle;
+
+        let handle = file.into_raw_handle();
+        // SAFETY: `handle` is a valid, owned handle obtained from `into_raw_handle()`.
+        match unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) } {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
+    }
+    #[cfg(not(any(target_family = "unix", target_family = "windows")))]
+    {
+        drop(file);
+        Ok(())
+    }
+}
+
 /// Local filesystem storage providing an [`ObjectStore`] interface to files on
 /// local disk. Can optionally be created with a directory prefix
 ///
@@ -359,16 +385,17 @@ impl ObjectStore for LocalFileSystem {
                         path: path.to_string_lossy().to_string(),
                     })?;
                     e_tag = Some(get_etag(&metadata));
+                    // Explicitly close the file, checking for errors that would be silently ignored by drop.
+                    // On network filesystems (e.g. NFS), close can fail and indicate data loss.
+                    //
+                    // This also ensures the file is closed before rename, which is required by some FUSE
+                    // filesystems (e.g. Blobfuse) to trigger the upload operation.
+                    close_file(file).map_err(|source| Error::UnableToCopyDataToFile { source })?;
                     match opts.mode {
-                        PutMode::Overwrite => {
-                            // For some fuse types of file systems, the file must be closed first
-                            // to trigger the upload operation, and then renamed, such as Blobfuse
-                            std::mem::drop(file);
-                            match std::fs::rename(&staging_path, &path) {
-                                Ok(_) => None,
-                                Err(source) => Some(Error::UnableToRenameFile { source }),
-                            }
-                        }
+                        PutMode::Overwrite => match std::fs::rename(&staging_path, &path) {
+                            Ok(_) => None,
+                            Err(source) => Some(Error::UnableToRenameFile { source }),
+                        },
                         PutMode::Create => match std::fs::hard_link(&staging_path, &path) {
                             Ok(_) => {
                                 let _ = std::fs::remove_file(&staging_path); // Attempt to cleanup
@@ -840,7 +867,7 @@ struct LocalUpload {
 #[derive(Debug)]
 struct UploadState {
     dest: PathBuf,
-    file: Mutex<File>,
+    file: Mutex<Option<File>>,
 }
 
 impl LocalUpload {
@@ -848,7 +875,7 @@ impl LocalUpload {
         Self {
             state: Arc::new(UploadState {
                 dest,
-                file: Mutex::new(file),
+                file: Mutex::new(Some(file)),
             }),
             src: Some(src),
             offset: 0,
@@ -864,7 +891,8 @@ impl MultipartUpload for LocalUpload {
 
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
-            let mut file = s.file.lock();
+            let mut guard = s.file.lock();
+            let file = guard.as_mut().ok_or(Error::Aborted)?;
             file.seek(SeekFrom::Start(offset)).map_err(|source| {
                 let path = s.dest.clone();
                 Error::Seek { source, path }
@@ -884,13 +912,23 @@ impl MultipartUpload for LocalUpload {
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             // Ensure no inflight writes
-            let file = s.file.lock();
-            std::fs::rename(&src, &s.dest)
-                .map_err(|source| Error::UnableToRenameFile { source })?;
+            let mut guard = s.file.lock();
+            let file = guard.take().ok_or(Error::Aborted)?;
+
             let metadata = file.metadata().map_err(|e| Error::Metadata {
                 source: e.into(),
                 path: src.to_string_lossy().to_string(),
             })?;
+
+            // Explicitly close the file, checking for errors that would be silently ignored by drop.
+            // On network filesystems (e.g. NFS), close can fail and indicate data loss.
+            //
+            // This also ensures the file is closed before rename, which is required by some FUSE
+            // filesystems (e.g. Blobfuse) to trigger the upload operation.
+            close_file(file).map_err(|source| Error::UnableToCopyDataToFile { source })?;
+
+            std::fs::rename(&src, &s.dest)
+                .map_err(|source| Error::UnableToRenameFile { source })?;
 
             Ok(PutResult {
                 e_tag: Some(get_etag(&metadata)),
@@ -1846,6 +1884,47 @@ mod tests {
         assert!(fs::read_dir(root.path()).unwrap().count() > 0);
         integration.delete(&location).await.unwrap();
         assert!(fs::read_dir(root.path()).unwrap().count() == 0);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_close_file_detects_error_unix() {
+        use std::os::fd::FromRawFd;
+        use std::os::unix::io::AsRawFd;
+
+        let file = tempfile::tempfile().unwrap();
+
+        // Close and reclaim a File from the now-invalid fd
+        let file = {
+            let fd = file.as_raw_fd();
+            super::close_file(file).unwrap();
+            unsafe { std::fs::File::from_raw_fd(fd) }
+        };
+
+        let err = super::close_file(file).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(nix::libc::EBADF), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_family = "windows")]
+    fn test_close_file_detects_error_windows() {
+        use std::os::windows::io::{AsRawHandle, FromRawHandle};
+
+        let file = tempfile::tempfile().unwrap();
+
+        // Close and reclaim a File from the now-invalid handle
+        let file = {
+            let handle = file.as_raw_handle();
+            super::close_file(file).unwrap();
+            unsafe { std::fs::File::from_raw_handle(handle) }
+        };
+
+        let err = super::close_file(file).unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(windows_sys::Win32::Foundation::ERROR_INVALID_HANDLE as i32),
+            "got: {err:?}"
+        );
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Implements one part of #661.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See issue. This PR is limited to explicitly calling `close` on written files with error checking.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `close_file()` helper that calls `libc::close()` (Unix) / `CloseHandle` (Windows) directly and propagates errors, instead of relying on `File::drop()`. Note that this uses `unsafe`, like in the platforms' respective `drop()` implementations.
- Apply both to the `put` and `put_multipart` (via `LocalUpload`) code paths.
- Add `libc` (Unix) and `windows-sys` (Windows) as optional dependencies behind the `fs` feature for their respective platforms.
- Add unit test verifying `close_file` detects `EBADF` when the file descriptor is closed behind Rust's back. This is just to validate that `close_file` properly returns the OS error.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

Close errors are now detected and propagated as `Error::UnableToCopyDataToFile`. Previously these were silently ignored. This is a correctness improvement but could surface errors that were previously hidden.
