### PR TITLE
fix(memory): fix out-of-order multipart upload for in-memory store

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -632,6 +632,7 @@ mod tests {
         rename_and_copy(&integration).await;
         stream_get(&integration).await;
         multipart(&integration, &integration).await;
+        multipart_put_part_out_of_order(&integration, &integration).await;
         multipart_race_condition(&integration, true).await;
         multipart_out_of_order(&integration).await;
         signing(&integration).await;

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -353,6 +353,7 @@ mod tests {
         stream_get(&integration).await;
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
+        multipart_put_part_out_of_order(&integration, &integration).await;
         multipart_race_condition(&integration, false).await;
         multipart_out_of_order(&integration).await;
         signing(&integration).await;

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -329,6 +329,7 @@ mod test {
             // https://github.com/fsouza/fake-gcs-server/issues/852
             stream_get(&integration).await;
             multipart(&integration, &integration).await;
+            multipart_put_part_out_of_order(&integration, &integration).await;
             multipart_race_condition(&integration, true).await;
             multipart_out_of_order(&integration).await;
             list_paginated(&integration, &integration).await;

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1059,20 +1059,26 @@ pub async fn multipart_put_part_out_of_order(
 ) {
     let path = Path::from("test_multipart_put_part_out_of_order");
 
+    // S3: each part except the last must be ≥ 5 MiB.
+    const MIN_MULTIPART_PART: usize = 5 * 1024 * 1024;
+    let part0_data = Bytes::from(vec![0xAA_u8; MIN_MULTIPART_PART]);
+    let part1_data = Bytes::from(vec![0xBB_u8; MIN_MULTIPART_PART]);
+    let part2_data = Bytes::from_static(b"tail");
+
     let upload_id = multipart.create_multipart(&path).await.unwrap();
 
     let part2 = multipart
-        .put_part(&path, &upload_id, 2, PutPayload::from(Bytes::from("part2")))
+        .put_part(&path, &upload_id, 2, PutPayload::from(part2_data.clone()))
         .await
         .unwrap();
 
     let part0 = multipart
-        .put_part(&path, &upload_id, 0, PutPayload::from(Bytes::from("part0")))
+        .put_part(&path, &upload_id, 0, PutPayload::from(part0_data.clone()))
         .await
         .unwrap();
 
     let part1 = multipart
-        .put_part(&path, &upload_id, 1, PutPayload::from(Bytes::from("part1")))
+        .put_part(&path, &upload_id, 1, PutPayload::from(part1_data.clone()))
         .await
         .unwrap();
 
@@ -1083,7 +1089,17 @@ pub async fn multipart_put_part_out_of_order(
     assert!(result.e_tag.is_some(), "Expected e_tag in PutResult");
 
     let data = storage.get(&path).await.unwrap().bytes().await.unwrap();
-    assert_eq!(data.as_ref(), b"part0part1part2");
+    assert_eq!(
+        data.len(),
+        part0_data.len() + part1_data.len() + part2_data.len()
+    );
+    assert!(data[..MIN_MULTIPART_PART].iter().all(|&b| b == 0xAA));
+    assert!(
+        data[MIN_MULTIPART_PART..2 * MIN_MULTIPART_PART]
+            .iter()
+            .all(|&b| b == 0xBB)
+    );
+    assert_eq!(&data[2 * MIN_MULTIPART_PART..], part2_data.as_ref());
 }
 
 async fn delete_fixtures(storage: &DynObjectStore) {

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1052,6 +1052,40 @@ pub async fn multipart(storage: &dyn ObjectStore, multipart: &dyn MultipartStore
     assert_eq!(meta.size, 0);
 }
 
+/// Tests that [`MultipartStore::put_part`] may be invoked with non-sequential part indices.
+pub async fn multipart_put_part_out_of_order(
+    storage: &dyn ObjectStore,
+    multipart: &dyn MultipartStore,
+) {
+    let path = Path::from("test_multipart_put_part_out_of_order");
+
+    let upload_id = multipart.create_multipart(&path).await.unwrap();
+
+    let part2 = multipart
+        .put_part(&path, &upload_id, 2, PutPayload::from(Bytes::from("part2")))
+        .await
+        .unwrap();
+
+    let part0 = multipart
+        .put_part(&path, &upload_id, 0, PutPayload::from(Bytes::from("part0")))
+        .await
+        .unwrap();
+
+    let part1 = multipart
+        .put_part(&path, &upload_id, 1, PutPayload::from(Bytes::from("part1")))
+        .await
+        .unwrap();
+
+    let result = multipart
+        .complete_multipart(&path, &upload_id, vec![part0, part1, part2])
+        .await
+        .unwrap();
+    assert!(result.e_tag.is_some(), "Expected e_tag in PutResult");
+
+    let data = storage.get(&path).await.unwrap().bytes().await.unwrap();
+    assert_eq!(data.as_ref(), b"part0part1part2");
+}
+
 async fn delete_fixtures(storage: &DynObjectStore) {
     let paths = storage.list(None).map_ok(|meta| meta.location).boxed();
     storage

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -433,7 +433,7 @@ impl MultipartStore for InMemory {
     ) -> Result<PartId> {
         let mut storage = self.storage.write();
         let upload = storage.upload_mut(id)?;
-        if part_idx <= upload.parts.len() {
+        if part_idx >= upload.parts.len() {
             upload.parts.resize(part_idx + 1, None);
         }
         upload.parts[part_idx] = Some(payload.into());
@@ -609,6 +609,43 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(&*read_data, data);
+    }
+
+    #[tokio::test]
+    async fn multipart_upload_out_of_order_put_part() {
+        use crate::multipart::MultipartStore;
+
+        let store = InMemory::new();
+        let path = Path::from("test_out_of_order");
+
+        let upload_id = store.create_multipart(&path).await.unwrap();
+
+        let part2_data = PutPayload::from(Bytes::from("part2"));
+        let part2 = store
+            .put_part(&path, &upload_id, 2, part2_data)
+            .await
+            .unwrap();
+
+        let part0_data = PutPayload::from(Bytes::from("part0"));
+        let part0 = store
+            .put_part(&path, &upload_id, 0, part0_data)
+            .await
+            .unwrap();
+
+        let part1_data = PutPayload::from(Bytes::from("part1"));
+        let part1 = store
+            .put_part(&path, &upload_id, 1, part1_data)
+            .await
+            .unwrap();
+
+        let result = store
+            .complete_multipart(&path, &upload_id, vec![part0, part1, part2])
+            .await
+            .unwrap();
+        assert!(result.e_tag.is_some(), "Expected e_tag in PutResult");
+
+        let data = store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(data.as_ref(), b"part0part1part2");
     }
 
     const NON_EXISTENT_NAME: &str = "nonexistentname";

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -558,6 +558,7 @@ mod tests {
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
         put_get_attributes(&integration).await;
+        multipart_put_part_out_of_order(&integration, &integration).await;
     }
 
     #[tokio::test]
@@ -609,43 +610,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(&*read_data, data);
-    }
-
-    #[tokio::test]
-    async fn multipart_upload_out_of_order_put_part() {
-        use crate::multipart::MultipartStore;
-
-        let store = InMemory::new();
-        let path = Path::from("test_out_of_order");
-
-        let upload_id = store.create_multipart(&path).await.unwrap();
-
-        let part2_data = PutPayload::from(Bytes::from("part2"));
-        let part2 = store
-            .put_part(&path, &upload_id, 2, part2_data)
-            .await
-            .unwrap();
-
-        let part0_data = PutPayload::from(Bytes::from("part0"));
-        let part0 = store
-            .put_part(&path, &upload_id, 0, part0_data)
-            .await
-            .unwrap();
-
-        let part1_data = PutPayload::from(Bytes::from("part1"));
-        let part1 = store
-            .put_part(&path, &upload_id, 1, part1_data)
-            .await
-            .unwrap();
-
-        let result = store
-            .complete_multipart(&path, &upload_id, vec![part0, part1, part2])
-            .await
-            .unwrap();
-        assert!(result.e_tag.is_some(), "Expected e_tag in PutResult");
-
-        let data = store.get(&path).await.unwrap().bytes().await.unwrap();
-        assert_eq!(data.as_ref(), b"part0part1part2");
     }
 
     const NON_EXISTENT_NAME: &str = "nonexistentname";

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -304,6 +304,7 @@ mod tests {
         let store = PrefixStore::new(InMemory::new(), "prefix");
 
         multipart(&store, &store).await;
+        multipart_put_part_out_of_order(&store, &store).await;
         multipart_out_of_order(&store).await;
         multipart_race_condition(&store, true).await;
     }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -400,6 +400,7 @@ mod tests {
         copy_if_not_exists(&store).await;
         stream_get(&store).await;
         multipart(&store, &store).await;
+        multipart_put_part_out_of_order(&store, &store).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-rs-object-store/issues/682

# Rationale for this change
 
IIRC, I think current implement will shrink parts and lose already-uploaded parts.

# What changes are included in this PR?

This PR resize in-memory store part vector only for increasing capacity.

# Are there any user-facing changes?

No
