### PR TITLE
[minor] remove unused macro definition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2154,16 +2154,6 @@ mod tests {
 
     use chrono::TimeZone;
 
-    macro_rules! maybe_skip_integration {
-        () => {
-            if std::env::var("TEST_INTEGRATION").is_err() {
-                eprintln!("Skipping integration test - set TEST_INTEGRATION");
-                return;
-            }
-        };
-    }
-    pub(crate) use maybe_skip_integration;
-
     /// Test that the returned stream does not borrow the lifetime of Path
     fn list_store<'a>(
         store: &'a dyn ObjectStore,


### PR DESCRIPTION
# Rationale for this change
 
I met unused warning at compilation
```sh
[~/arrow-rs-object-store] (main) 
vscode@bf21a2fa9d74$ cargo test --lib in_memory_test
   Compiling object_store v0.13.2 (/home/vscode/arrow-rs-object-store)
warning: unused macro definition: `maybe_skip_integration`
    --> src/lib.rs:2157:18
     |
2157 |     macro_rules! maybe_skip_integration {
     |                  ^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_macros)]` on by default

warning: unused import: `maybe_skip_integration`
    --> src/lib.rs:2165:20
     |
2165 |     pub(crate) use maybe_skip_integration;
     |                    ^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_imports)]` on by default
```

# What changes are included in this PR?

This PR removes unused macro, which is complaint by compiler.

# Are there any user-facing changes?

No