### PR TITLE
fix[prefix]: strip_meta from get_opts result in PrefixStore

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -177,6 +177,7 @@ pub async fn put_get_delete_list(storage: &DynObjectStore) {
 
     let head = storage.head(&location).await.unwrap();
     assert_eq!(head.size, data.len() as u64);
+    assert_eq!(head.location, location);
 
     storage.delete(&location).await.unwrap();
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -117,7 +117,9 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let full_path = self.full_path(location);
-        self.inner.get_opts(&full_path, options).await
+        let mut result = self.inner.get_opts(&full_path, options).await?;
+        result.meta = self.strip_meta(result.meta);
+        Ok(result)
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
@@ -297,6 +299,26 @@ mod tests {
         let location = Path::from("prefix/test_written.json");
         let read_data = local.get(&location).await.unwrap().bytes().await.unwrap();
         assert_eq!(&*read_data, data)
+    }
+
+    // Regression test for
+    // https://github.com/apache/arrow-rs-object-store/issues/664:
+    // head/get returned an ObjectMeta whose location still contained the
+    // prefix, so round-tripping the returned location back into the store would
+    // double-prefix it.
+    #[tokio::test]
+    async fn prefix_head_get_strip_prefix() {
+        let store = PrefixStore::new(InMemory::new(), "prefix");
+        let path = Path::from("test_file");
+        store.put(&path, "data".into()).await.unwrap();
+
+        let head = store.head(&path).await.unwrap();
+        assert_eq!(head.location, path);
+        let get = store.get(&path).await.unwrap();
+        assert_eq!(get.meta.location, path);
+
+        // The returned location must round-trip back into the same store.
+        store.get(&head.location).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
PrefixStore was incorrectly not stripping the prefix from the returned result.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #664
Closes #670

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Fix regression

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Fix + assertion in integration tests + regression test

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
