### PR TITLE
fix(core): add missing extension assignment

### DIFF
--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -446,6 +446,7 @@ impl AsyncWrite for BufWriter {
                     let opts = PutOptions {
                         attributes: self.attributes.take().unwrap_or_default(),
                         tags: self.tags.take().unwrap_or_default(),
+                        extensions: self.extensions.take().unwrap_or_default(),
                         ..Default::default()
                     };
                     let store = Arc::clone(&self.store);

--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -117,8 +117,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-            common_prefixes.extend(response.common_prefixes.into_iter());
-            objects.extend(response.objects.into_iter());
+            common_prefixes.extend(response.common_prefixes);
+            objects.extend(response.objects);
         }
 
         Ok(ListResult {


### PR DESCRIPTION
# Rationale for this change
 
Disclaimer: this issues was discovered by opus when I was leverage LLM to read through the code.

This PR adds missing extension through BufWriter single put shutdown path.
Reading through the codebase, it reads to me "attributes", "tags" and "extensions" should all be assigned for `PutOptions`.

Another example for multipart upload options https://github.com/apache/arrow-rs-object-store/blob/e89f62b6508f6f65873ce6a5017cd0d5d7395184/src/buffered.rs#L341-L344

# What changes are included in this PR?

This PR passes the missing `extension` field to `PutOption`.

# Are there any user-facing changes?

No