### PR TITLE
fix(retry): respect range header on retry

### DIFF
--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -244,7 +244,48 @@ impl<T: GetClient> GetContext<T> {
                                 return Err(Self::err(e));
                             }
 
-                            body = retry_body;
+                            // Validate the Content-Range of the retry response
+                            let content_range =
+                                parse_range(&parts.headers).map_err(Self::err)?;
+                            let actual = content_range.range;
+
+                            // Exact match — use body as-is
+                            if actual == range {
+                                body = retry_body;
+                            } else if actual.start <= range.start && actual.end >= range.end
+                            {
+                                // Received range is a superset for requested content,
+                                // skip leading bytes to align to the needed offset.
+                                let skip = (range.start - actual.start) as usize;
+                                let mut skipped = 0;
+                                let mut retry_body = retry_body;
+                                while skipped < skip {
+                                    let frame = retry_body.frame().await
+                                        .ok_or_else(|| Self::err(GetResultError::UnexpectedRange {
+                                            expected: range.clone(), actual: actual.clone(),
+                                        }))?
+                                        .map_err(Self::err)?;
+                                    let Some(bytes) = frame.into_data().ok() else { continue };
+                                    let remaining = skip - skipped;
+                                    if bytes.len() <= remaining {
+                                        skipped += bytes.len();
+                                    } else {
+                                        let keep = bytes.slice(remaining..);
+                                        range.start += keep.len() as u64;
+                                        body = retry_body;
+                                        let etag = Some(etag.clone());
+                                        return Ok(Some((keep, (ctx, body, etag, range))));
+                                    }
+                                }
+                                body = retry_body;
+                            } else {
+                                return Err(Self::err(
+                                    GetResultError::UnexpectedRange {
+                                        expected: range,
+                                        actual,
+                                    },
+                                ));
+                            }
                         }
                         (Err(e), _) => return Err(Self::err(e)),
                     }
@@ -770,6 +811,59 @@ mod http_tests {
         assert_eq!(
             err.to_string(),
             "Generic HTTP error: HTTP error: request or response body error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_validate_content_range() {
+        let mock = MockServer::new().await;
+        let retry = RetryConfig {
+            backoff: Default::default(),
+            max_retries: 3,
+            retry_timeout: Duration::from_secs(1000),
+        };
+
+        let options = ClientOptions::new().with_allow_http(true);
+        let store = HttpBuilder::new()
+            .with_client_options(options)
+            .with_retry(retry)
+            .with_url(mock.url())
+            .build()
+            .unwrap();
+
+        let path = Path::from("test");
+
+        mock.push(
+            Response::builder()
+                .header(CONTENT_LENGTH, 10)
+                .header(ETAG, "abc")
+                .body(Chunked::new(vec![
+                    Ok(Bytes::from_static(b"hello")),
+                    Err(()),
+                ]))
+                .unwrap(),
+        );
+
+        mock.push_fn(|req| {
+            assert_eq!(
+                req.headers().get(RANGE).unwrap().to_str().unwrap(),
+                "bytes=5-9"
+            );
+
+            Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(CONTENT_LENGTH, 10)
+                .header(ETAG, "abc")
+                .header(CONTENT_RANGE, "bytes 0-9/10")
+                .body("helloworld".to_string())
+                .unwrap()
+        });
+
+        let result = store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(
+            result.as_ref(),
+            b"helloworld",
+            "expected correct 10-byte content"
         );
     }
 }

--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -117,8 +117,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-            common_prefixes.extend(response.common_prefixes.into_iter());
-            objects.extend(response.objects.into_iter());
+            common_prefixes.extend(response.common_prefixes);
+            objects.extend(response.objects);
         }
 
         Ok(ListResult {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs-object-store/issues/654

# Rationale for this change
 
Disclaimer: this PR tries to solve the same problem as https://github.com/apache/arrow-rs-object-store/pull/609, but did a different way: I tried to keep the bytes since I observe (for my usage personally) most of returned range is a superset for requested range. 
Feel free to close it if maintainers think it's a duplicate.

Currently retry stream returns returned body directly without checking the range header.
https://github.com/apache/arrow-rs-object-store/blob/e89f62b6508f6f65873ce6a5017cd0d5d7395184/src/client/get.rs#L247

# What changes are included in this PR?

Since retried response could contain ranges which don't match with requested one, so I tried to keep useful parts if applicable.

# Are there any user-facing changes?

No.