### PR TITLE
fix(core): add missing version assignment

### DIFF
--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -117,8 +117,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-            common_prefixes.extend(response.common_prefixes.into_iter());
-            objects.extend(response.objects.into_iter());
+            common_prefixes.extend(response.common_prefixes);
+            objects.extend(response.objects);
         }
 
         Ok(ListResult {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -92,11 +92,11 @@ fn strip_meta(prefix: &Path, meta: ObjectMeta) -> ObjectMeta {
         version,
     } = meta;
     ObjectMeta {
-        last_modified: last_modified,
-        size: size,
+        last_modified,
+        size,
         location: strip_prefix(prefix, location),
-        e_tag: e_tag,
-        version: version,
+        e_tag,
+        version,
     }
 }
 
@@ -326,6 +326,26 @@ mod tests {
 
         // The returned location must round-trip back into the same store.
         store.get(&head.location).await.unwrap();
+    }
+
+    #[test]
+    fn strip_meta_preserves_version_and_etag() {
+        let prefix = Path::from("prefix");
+        let meta = ObjectMeta {
+            location: Path::from("prefix/foo"),
+            last_modified: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            size: 42,
+            e_tag: Some("etag-value".to_string()),
+            version: Some("version-value".to_string()),
+        };
+
+        let stripped = strip_meta(&prefix, meta.clone());
+
+        assert_eq!(stripped.location, Path::from("foo"));
+        assert_eq!(stripped.last_modified, meta.last_modified);
+        assert_eq!(stripped.size, meta.size);
+        assert_eq!(stripped.e_tag, meta.e_tag);
+        assert_eq!(stripped.version, meta.version);
     }
 
     #[tokio::test]

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -84,12 +84,19 @@ fn strip_prefix(prefix: &Path, path: Path) -> Path {
 
 /// Strip the constant prefix from a given ObjectMeta
 fn strip_meta(prefix: &Path, meta: ObjectMeta) -> ObjectMeta {
+    let ObjectMeta {
+        last_modified,
+        size,
+        location,
+        e_tag,
+        version,
+    } = meta;
     ObjectMeta {
-        last_modified: meta.last_modified,
-        size: meta.size,
-        location: strip_prefix(prefix, meta.location),
-        e_tag: meta.e_tag,
-        version: meta.version,
+        last_modified: last_modified,
+        size: size,
+        location: strip_prefix(prefix, location),
+        e_tag: e_tag,
+        version: version,
     }
 }
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -339,13 +339,19 @@ mod tests {
             version: Some("version-value".to_string()),
         };
 
-        let stripped = strip_meta(&prefix, meta.clone());
+        let ObjectMeta {
+            location,
+            last_modified,
+            size,
+            e_tag,
+            version,
+        } = strip_meta(&prefix, meta.clone());
 
-        assert_eq!(stripped.location, Path::from("foo"));
-        assert_eq!(stripped.last_modified, meta.last_modified);
-        assert_eq!(stripped.size, meta.size);
-        assert_eq!(stripped.e_tag, meta.e_tag);
-        assert_eq!(stripped.version, meta.version);
+        assert_eq!(location, Path::from("foo"));
+        assert_eq!(last_modified, meta.last_modified);
+        assert_eq!(size, meta.size);
+        assert_eq!(e_tag, meta.e_tag);
+        assert_eq!(version, meta.version);
     }
 
     #[tokio::test]

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -89,7 +89,7 @@ fn strip_meta(prefix: &Path, meta: ObjectMeta) -> ObjectMeta {
         size: meta.size,
         location: strip_prefix(prefix, meta.location),
         e_tag: meta.e_tag,
-        version: None,
+        version: meta.version,
     }
 }
 


### PR DESCRIPTION
# What changes are included in this PR?

This PR adds missing `version` field assignment for `ObjectMetadata`.

# Are there any user-facing changes?

No.