### PR TITLE
fix: clippy

### DIFF
--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -117,8 +117,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-            common_prefixes.extend(response.common_prefixes.into_iter());
-            objects.extend(response.objects.into_iter());
+            common_prefixes.extend(response.common_prefixes);
+            objects.extend(response.objects);
         }
 
         Ok(ListResult {


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
`clippy` broken on `main` after Rust 1.95 release.

# What changes are included in this PR?
Lint fixes.

# Are there any user-facing changes?
\-