### PR TITLE
fix(azure): fall back to client-side filtering for list_with_offset on OneLake

### DIFF
--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -127,11 +127,20 @@ impl ObjectStore for MicrosoftAzure {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, Result<ObjectMeta>> {
-        if self.client.config().is_emulator {
-            // Azurite doesn't support the startFrom query parameter,
+        let disable_start_from = self.client.config().is_emulator
+            || self
+                .client
+                .config()
+                .service
+                .host_str()
+                .is_some_and(|h| h.ends_with(".fabric.microsoft.com"));
+
+        if disable_start_from {
+            // Azurite and OneLake don't support the startFrom query parameter,
             // fall back to client-side filtering
             //
             // See https://github.com/Azure/Azurite/issues/2619#issuecomment-3660701055
+            // See https://github.com/apache/arrow-rs-object-store/issues/695
             let offset = offset.clone();
             self.list(prefix)
                 .try_filter(move |f| futures_util::future::ready(f.location > offset))

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -419,6 +419,114 @@ mod tests {
         assert_eq!(data, loaded);
     }
 
+    /// Verifies that `list_with_offset` works against OneLake (Fabric) endpoints.
+    ///
+    /// OneLake silently ignores the `startFrom` query parameter, so the client
+    /// must fall back to client-side filtering.
+    ///
+    /// Set these env vars before running:
+    /// - `AZURE_STORAGE_TOKEN`: bearer token (e.g. from `az account get-access-token`)
+    /// - `ONELAKE_URL`: full OneLake table URL, e.g.
+    ///   `https://onelake.dfs.fabric.microsoft.com/<ws>/<item>/Tables/<table>`
+    ///
+    /// See <https://github.com/apache/arrow-rs-object-store/issues/695>
+    #[ignore = "Used for manual testing against a real OneLake endpoint."]
+    #[tokio::test]
+    async fn test_onelake_list_with_offset() {
+        let url = std::env::var("ONELAKE_URL").unwrap();
+        let token = std::env::var("AZURE_STORAGE_TOKEN").unwrap();
+
+        let store = MicrosoftAzureBuilder::new()
+            .with_url(&url)
+            .with_config(AzureConfigKey::Token, token)
+            .build()
+            .unwrap();
+
+        // Derive a writable path prefix from the URL
+        // (skip workspace segment which becomes the container)
+        let parsed: Url = url.parse().unwrap();
+        let mut segments = parsed.path_segments().unwrap();
+        let _workspace = segments.next().unwrap();
+        let base: String = segments.collect::<Vec<_>>().join("/");
+        let test_dir = format!("{base}/test_onelake_offset");
+
+        // Create test files with predictable ordering
+        let prefix = Path::from(test_dir.as_str());
+        let files: Vec<Path> = (b'a'..=b'e')
+            .map(|c| Path::from(format!("{test_dir}/file_{}.txt", c as char)))
+            .collect();
+        let data = Bytes::from("test data");
+        for file in &files {
+            store.put(file, data.clone().into()).await.unwrap();
+        }
+
+        // Test 1: Offset at file_b → should return c, d, e (not b)
+        let offset = Path::from(format!("{test_dir}/file_b.txt"));
+        let result: Vec<Path> = store
+            .list_with_offset(Some(&prefix), &offset)
+            .map_ok(|m| m.location)
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(
+            !result.contains(&offset),
+            "offset file_b should be excluded, got: {result:?}"
+        );
+        assert_eq!(result.len(), 3, "expected c/d/e after file_b, got: {result:?}");
+
+        // Test 2: Offset at file_a → should return b, c, d, e
+        let offset = Path::from(format!("{test_dir}/file_a.txt"));
+        let result: Vec<Path> = store
+            .list_with_offset(Some(&prefix), &offset)
+            .map_ok(|m| m.location)
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(!result.contains(&offset), "offset file_a should be excluded");
+        assert_eq!(result.len(), 4, "expected b/c/d/e after file_a, got: {result:?}");
+
+        // Test 3: Offset at file_e (last) → should return empty
+        let offset = Path::from(format!("{test_dir}/file_e.txt"));
+        let result: Vec<Path> = store
+            .list_with_offset(Some(&prefix), &offset)
+            .map_ok(|m| m.location)
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(result.is_empty(), "offset at last file should return empty, got: {result:?}");
+
+        // Test 4: Offset before all files → should return all 5
+        let offset = Path::from(format!("{test_dir}/file"));
+        let result: Vec<Path> = store
+            .list_with_offset(Some(&prefix), &offset)
+            .map_ok(|m| m.location)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 5, "offset before all files should return all, got: {result:?}");
+
+        // Test 5: Every returned entry is strictly greater than offset
+        let offset = Path::from(format!("{test_dir}/file_c.txt"));
+        let result: Vec<ObjectMeta> = store
+            .list_with_offset(Some(&prefix), &offset)
+            .try_collect()
+            .await
+            .unwrap();
+        for meta in &result {
+            assert!(
+                meta.location > offset,
+                "entry {} should be > offset {}",
+                meta.location,
+                offset
+            );
+        }
+
+        // Cleanup
+        for file in &files {
+            let _ = store.delete(file).await;
+        }
+    }
+
     #[test]
     fn azure_test_config_get_value() {
         let azure_client_id = "object_store:fake_access_key_id".to_string();

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -421,13 +421,15 @@ mod tests {
 
     /// Verifies that `list_with_offset` works against OneLake (Fabric) endpoints.
     ///
-    /// OneLake silently ignores the `startFrom` query parameter, so the client
-    /// must fall back to client-side filtering.
+    /// OneLake silently ignores the `startFrom` query parameter when using
+    /// friendly-name URLs (e.g. `.../MyWorkspace/lakehouse.Lakehouse/...`),
+    /// returning 200 OK with zero results.
+    /// GUID-based URLs handle `startFrom` correctly.
     ///
     /// Set these env vars before running:
     /// - `AZURE_STORAGE_TOKEN`: bearer token (e.g. from `az account get-access-token`)
-    /// - `ONELAKE_URL`: full OneLake URL, e.g.
-    ///   `https://onelake.blob.fabric.microsoft.com/<ws>/<item>/Files/`
+    /// - `ONELAKE_URL`: full OneLake URL with friendly names, e.g.
+    ///   `https://onelake.blob.fabric.microsoft.com/<workspace>/<item>.Lakehouse/`
     ///
     /// See <https://github.com/apache/arrow-rs-object-store/issues/695>
     #[ignore = "Used for manual testing against a real OneLake endpoint."]

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -472,7 +472,11 @@ mod tests {
             !result.contains(&offset),
             "offset file_b should be excluded, got: {result:?}"
         );
-        assert_eq!(result.len(), 3, "expected c/d/e after file_b, got: {result:?}");
+        assert_eq!(
+            result.len(),
+            3,
+            "expected c/d/e after file_b, got: {result:?}"
+        );
 
         // Test 2: Offset at file_a → should return b, c, d, e
         let offset = Path::from(format!("{test_dir}/file_a.txt"));
@@ -482,8 +486,15 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
-        assert!(!result.contains(&offset), "offset file_a should be excluded");
-        assert_eq!(result.len(), 4, "expected b/c/d/e after file_a, got: {result:?}");
+        assert!(
+            !result.contains(&offset),
+            "offset file_a should be excluded"
+        );
+        assert_eq!(
+            result.len(),
+            4,
+            "expected b/c/d/e after file_a, got: {result:?}"
+        );
 
         // Test 3: Offset at file_e (last) → should return empty
         let offset = Path::from(format!("{test_dir}/file_e.txt"));
@@ -493,7 +504,10 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
-        assert!(result.is_empty(), "offset at last file should return empty, got: {result:?}");
+        assert!(
+            result.is_empty(),
+            "offset at last file should return empty, got: {result:?}"
+        );
 
         // Test 4: Offset before all files → should return all 5
         let offset = Path::from(format!("{test_dir}/file"));
@@ -503,7 +517,11 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
-        assert_eq!(result.len(), 5, "offset before all files should return all, got: {result:?}");
+        assert_eq!(
+            result.len(),
+            5,
+            "offset before all files should return all, got: {result:?}"
+        );
 
         // Test 5: Every returned entry is strictly greater than offset
         let offset = Path::from(format!("{test_dir}/file_c.txt"));

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -426,8 +426,8 @@ mod tests {
     ///
     /// Set these env vars before running:
     /// - `AZURE_STORAGE_TOKEN`: bearer token (e.g. from `az account get-access-token`)
-    /// - `ONELAKE_URL`: full OneLake table URL, e.g.
-    ///   `https://onelake.dfs.fabric.microsoft.com/<ws>/<item>/Tables/<table>`
+    /// - `ONELAKE_URL`: full OneLake URL, e.g.
+    ///   `https://onelake.blob.fabric.microsoft.com/<ws>/<item>/Files/`
     ///
     /// See <https://github.com/apache/arrow-rs-object-store/issues/695>
     #[ignore = "Used for manual testing against a real OneLake endpoint."]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #695.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`list_with_offset` returns empty results on OneLake when **both** of the following conditions are met:

1. **Friendly-name URLs** — the endpoint addresses the workspace and lakehouse by display name (e.g. `onelake.blob.fabric.microsoft.com/MyWorkspace/lakehouse.Lakehouse/...`) rather than by GUID
2. **`startFrom` query parameter** — the `List Blobs` request includes `startFrom`, which OneLake silently ignores in this case, returning 200 OK with zero results rather than rejecting the request

(Note that when using GUID-based URLs (`onelake.blob.fabric.microsoft.com/{workspace-guid}`), `startFrom` works correctly.)

This regression was introduced in #623 which implemented optimizations using `startFrom` pushdown.

We (The OneLake team) are actively fixing `startFrom` with friendly-name URLs on our side. 
In the meantime, `object_store` can fall back to client-side filtering for OneLake endpoints.
I created a tracking issue (#697) to re-enable this optimization for OneLake once the fix is complete


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Auto-detect Fabric/OneLake endpoints (`*.fabric.microsoft.com`) and skip `startFrom`, falling back to client-side filtering -- same approach already used for Azurite
- Add `#[ignore]` integration test (`test_onelake_list_with_offset`) that verifies offset exclusivity, boundary cases, and ordering against a live OneLake endpoint

### Tested locally
GUID-based URI works:
```
export AZURE_STORAGE_TOKEN=$(az account get-access-token --resource https://storage.azure.com/ --query accessToken -o tsv) && \
ONELAKE_URL="https://msit-onelake.blob.fabric.microsoft.com/OLSTeamWorkspace/lh.Lakehouse/Files/test_startfrom" \
cargo test --features azure test_onelake_list_with_offset -- --ignored --no-capture
```

Friendly name based URI fails:
```
export AZURE_STORAGE_TOKEN=$(az account get-access-token --resource https://storage.azure.com/ --query accessToken -o tsv) && \
ONELAKE_URL="https://msit-onelake.blob.fabric.microsoft.com/45a753bc-c074-42cf-8b30-5dfa920b241f/3e56af9e-3832-47ed-b18c-dcc58b562e87/Files/test_startfrom" \
cargo test --features azure test_onelake_list_with_offset -- --ignored --no-capture
```

# Are there any user-facing changes?
No, this is a behavioral change for `list_with_offset` against OneLake endpoints

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
