### PR TITLE
Add `with_signing_credentials` to GCP builder

### DIFF
--- a/src/gcp/builder.rs
+++ b/src/gcp/builder.rs
@@ -459,6 +459,12 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
+    /// Set the signing credential provider overriding any other options
+    pub fn with_signing_credentials(mut self, credentials: GcpSigningCredentialProvider) -> Self {
+        self.signing_credentials = Some(credentials);
+        self
+    }
+
     /// Set the retry configuration
     pub fn with_retry(mut self, retry_config: RetryConfig) -> Self {
         self.retry_config = retry_config;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #698.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See the linked issue for rationale and use cases.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This adds a `with_signing_credentials` method to the Google storage builder. No other changes are needed, because this field already exists internally and is picked up when creating the client.

# Are there any user-facing changes?

New builder option, no breaking changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
