### PR TITLE
Whitelisting Onelake API & Workspace PL FQDNs

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -666,10 +666,26 @@ impl MicrosoftAzureBuilder {
                     self.container_name = Some(validate(host)?);
                 } else {
                     match host.split_once('.') {
+                        // Workspace-level Private Link detection
+                        // "{workspaceid}.z??.(onelake|dfs|blob).fabric.microsoft.com"
+                        Some((workspaceid, rest))
+                            if rest.starts_with('z') && rest.ends_with("fabric.microsoft.com") =>
+                        {
+                            // Account name for WS-PL is two labels: "{workspaceid}.z{xy}"
+                            let (zone, _) = rest.split_once('.').unwrap_or((rest, ""));
+
+                            self.account_name = Some(format!("{workspaceid}.{zone}"));
+                            self.endpoint = Some(format!("https://{}", host));
+
+                            self.container_name = Some(validate(parsed.username())?);
+                            self.use_fabric_endpoint = true.into();
+                        }
+
                         Some((a, "dfs.core.windows.net")) | Some((a, "blob.core.windows.net")) => {
                             self.account_name = Some(validate(a)?);
                             self.container_name = Some(validate(parsed.username())?);
                         }
+
                         Some((a, "dfs.fabric.microsoft.com"))
                         | Some((a, "blob.fabric.microsoft.com")) => {
                             self.account_name = Some(validate(a)?);
@@ -681,6 +697,30 @@ impl MicrosoftAzureBuilder {
                 }
             }
             "https" => match host.split_once('.') {
+                // Workspace-level Private Link detection
+                // "{workspaceid}.z??.(onelake|dfs|blob).fabric.microsoft.com"
+                Some((workspaceid, rest))
+                    if rest.starts_with('z') && rest.ends_with("fabric.microsoft.com") =>
+                {
+                    // rest looks like: "z28.dfs.fabric.microsoft.com" / "z28.blob.fabric.microsoft.com" / etc.
+                    // Account name for WS-PL is two labels: "{workspaceid}.z{xy}"
+                    let (zone, _) = rest.split_once('.').unwrap_or((rest, ""));
+
+                    self.account_name = Some(format!("{workspaceid}.{zone}"));
+                    self.endpoint = Some(format!("https://{}", host));
+
+                    // Attempt to infer the container name from the URL
+                    let container = parsed.path_segments().unwrap().next().expect(
+                        "iterator always contains at least one string (which may be empty)",
+                    );
+
+                    if !container.is_empty() {
+                        self.container_name = Some(validate(container)?);
+                    }
+
+                    self.use_fabric_endpoint = true.into();
+                }
+
                 Some((a, "dfs.core.windows.net")) | Some((a, "blob.core.windows.net")) => {
                     self.account_name = Some(validate(a)?);
                     let container = parsed.path_segments().unwrap().next().expect(
@@ -1205,6 +1245,17 @@ mod tests {
 
         let mut builder = MicrosoftAzureBuilder::new();
         builder
+            .parse_url("https://onelake.dfs.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456.lakehouse/Files/tables/sales/data.parquet")
+            .unwrap();
+        assert_eq!(builder.account_name, Some("onelake".to_string()));
+        assert_eq!(
+            builder.container_name.as_deref(),
+            Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3")
+        );
+        assert!(builder.use_fabric_endpoint.get().unwrap());
+
+        let mut builder = MicrosoftAzureBuilder::new();
+        builder
             .parse_url("https://account.blob.fabric.microsoft.com/")
             .unwrap();
         assert_eq!(builder.account_name, Some("account".to_string()));
@@ -1231,6 +1282,77 @@ mod tests {
         let mut builder = MicrosoftAzureBuilder::new();
         for case in err_cases {
             builder.parse_url(case).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn azure_test_workspace_private_link() {
+        let test_cases: Vec<(&str, &str, Option<&str>)> = vec![
+            (
+                "https://Ab000000000000000000000000000000.zAb.dfs.fabric.microsoft.com/",
+                "ab000000000000000000000000000000.zab",
+                None,
+            ),
+            (
+                "https://ab000000000000000000000000000000.zab.dfs.fabric.microsoft.com/",
+                "ab000000000000000000000000000000.zab",
+                None,
+            ),
+            (
+                "https://c047b3e34e89407a98d7cf9949ae92a3.zc0.blob.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3"),
+            ),
+            (
+                "https://c047b3e34e89407a98d7cf9949ae92a3.zc0.dfs.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3"),
+            ),
+            (
+                "https://c047b3e34e89407a98d7cf9949ae92a3.zc0.onelake.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3"),
+            ),
+            (
+                "https://c047b3e34e89407a98d7cf9949ae92a3.zc0.w.api.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3"),
+            ),
+            (
+                "https://c047b3e34e89407a98d7cf9949ae92a3.zc0.c.api.fabric.microsoft.com/c047b3e3-4e89-407a-98d7-cf9949ae92a3/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e3-4e89-407a-98d7-cf9949ae92a3"),
+            ),
+            (
+                "abfss://c047b3e34e89407a98d7cf9949ae92a3@c047b3e34e89407a98d7cf9949ae92a3.zc0.dfs.fabric.microsoft.com/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e34e89407a98d7cf9949ae92a3"),
+            ),
+            (
+                "abfss://c047b3e34e89407a98d7cf9949ae92a3@c047b3e34e89407a98d7cf9949ae92a3.zc0.blob.fabric.microsoft.com/9f1a2b3c-4d5e-6f70-8a9b-c0d1e2f3a456/file",
+                "c047b3e34e89407a98d7cf9949ae92a3.zc0",
+                Some("c047b3e34e89407a98d7cf9949ae92a3"),
+            ),
+        ];
+
+        for (url, expected_account, expected_container) in &test_cases {
+            let mut builder = MicrosoftAzureBuilder::new();
+            builder.parse_url(url).unwrap();
+
+            assert_eq!(
+                builder.account_name.as_deref(),
+                Some(*expected_account),
+                "account mismatch for URL: {url}"
+            );
+            assert_eq!(
+                builder.container_name.as_deref(),
+                *expected_container,
+                "container mismatch for URL: {url}"
+            );
+            assert!(
+                builder.use_fabric_endpoint.get().unwrap(),
+                "use_fabric_endpoint not set for URL: {url}"
+            );
         }
     }
 

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -378,6 +378,47 @@ mod tests {
         }
     }
 
+    #[ignore = "Used for manual testing against a real Workspace Private Link Endpoint."]
+    #[tokio::test]
+    async fn azure_onelake_wspl_test() {
+        maybe_skip_integration!();
+
+        let url =
+            std::env::var("AZURE_ONELAKE_URL").expect("Set AZURE_ONELAKE_URL to a WS-PL FQDN");
+        let parsed = url::Url::parse(&url).unwrap();
+
+        let path = match parsed.scheme() {
+            "abfss" | "abfs" => {
+                // abfss://<container>@<host>/<path...>
+                // container is in username, entire path is the object path
+                let segments: Vec<&str> = parsed.path_segments().unwrap().collect();
+                Path::from(segments.join("/"))
+            }
+            _ => {
+                // https://<host>/<container>/<path...>
+                // first segment is container, rest is the object path
+                let segments: Vec<&str> = parsed.path_segments().unwrap().collect();
+                Path::from(segments[1..].join("/"))
+            }
+        };
+
+        let store = MicrosoftAzureBuilder::new()
+            .with_url(&url)
+            .with_bearer_token_authorization(
+                std::env::var("AZURE_STORAGE_TOKEN").expect("Set AZURE_STORAGE_TOKEN"),
+            )
+            .build()
+            .unwrap();
+
+        let data = Bytes::from("Hello OneLake WSPL");
+
+        store.put(&path, data.clone().into()).await.unwrap();
+        let result = store.get(&path).await.unwrap();
+        let loaded = result.bytes().await.unwrap();
+        assert_eq!(data, loaded);
+        store.delete(&path).await.unwrap();
+    }
+
     #[ignore = "Used for manual testing against a real storage account."]
     #[tokio::test]
     async fn test_user_delegation_key() {

--- a/src/client/list.rs
+++ b/src/client/list.rs
@@ -117,8 +117,8 @@ impl<T: ListClient + Clone> ListClientExt for T {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-            common_prefixes.extend(response.common_prefixes.into_iter());
-            objects.extend(response.objects.into_iter());
+            common_prefixes.extend(response.common_prefixes);
+            objects.extend(response.objects);
         }
 
         Ok(ListResult {


### PR DESCRIPTION
# Rationale for this change
 
1. With the release of the [WS PL FQDNs](https://learn.microsoft.com/en-us/fabric/security/security-workspace-level-private-links-overview#connecting-to-workspaces) with workspace private links, we need to add support for the new workspace FQDNs (“{wsid}.z{xy}.dfs.fabric.microsoft.com), so users can continue to use Delta-RS with OneLake and workspace private links.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. Valid WS-PL FQDN egs:
* abfss://7c09f7b8-d05f-4a0d-9534-c3cad6e25525@7c09f7b8d05f4a0d9534c3cad6e25525.z7c.msit-blob.fabri
c.microsoft.com/3f49a318-25a0-4100-948d-d08229390322/Files/test_delta_table
* https://c047b3e34e89407a98d7cf9949ae92a3.zc0.onelake.fabric.microsoft.com
* https://c047b3e34e89407a98d7cf9949ae92a3.zc0.dfs.fabric.microsoft.com
* https://7c09f7b8d05f4a0d9534c3cad6e25525.z7c.msit-blob.fabric.microsoft.com/7c09f7b8-d05f-4a0d-9534-c3cad6e25525/3f49a318-25a0-4100-948d-d08229390322/Files/Readme.txt
2. Invalid WS-PL FQDN egs:
* https://c047b3e34e89407a98d7cf9949ae92a3.z12.blob.fabric.microsoft.com // xy mismatch 
* https://c047b3e34e89407a98d7cf9949ae923.z12.blob.fabric.microsoft.com  // workspaceid 31 chars

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Testing Details

1. Unit Tests
 - _parse_url()_ correctly extracts account_name, endpoint, container_name, and sets use_fabric_endpoint = true for 
WS-PL hosts
 - Validates both abfss:// and https:// schemes with WS-PL FQDN patterns like 
{workspaceid}.z{xy}.msit-dfs.fabric.microsoft.com

2. Integration Testing
- In a VM where the workspace supporting private link is hosted, successfully ran newly added integration test on URLs like:
~ https://7c09f7b8d05f4a0d9534c3cad6e25525.z7c.msit-dfs.fabric.microsoft.com/7c09f7b8-d05f-4a0d-9534-c3cad6e25525/3f49a318-25a0-4100-948d-d08229390322/Files/integration_test_wspl.txt
~ abfss://7c09f7b8-d05f-4a0d-9534-c3cad6e25525@7c09f7b8d05f4a0d9534c3cad6e25525.z7c.msit-dfs.fabric.microsoft.com/3f49a318-25a0-4100-948d-d08229390322/Files/integration_test_wspl.txt

3. Delta-RS Local Patch
-  Patched latest delta-rs to use local object_store via _[patch.crates-io]_.
- Successfully ran Delta-RS integration test against a real ABFSS based (as https scheme is not supported by Delta-RS) WSPL link:
`
TABLE_URI = '' abfss://7c09f7b8-d05f-4a0d-9534-c3cad6e25525@7c09f7b8d05f4a0d9534c3cad6e25525.z7c.msit-blob.fabric.microsoft.com/3f49a318-25a0-4100-948d-d08229390322/Tables/dbo/wspltesttable"
cargo run -p deltalake --example basic_operations --features 'azure,datafusion'
`
<img width="310" height="483" alt="image" src="https://github.com/user-attachments/assets/74ff215c-904f-4960-b1d6-8c1fb4609883" />


# Are there any user-facing changes?
Yes. The documentaion is as below:
1. https://learn.microsoft.com/en-us/fabric/security/security-workspace-level-private-links-overview#connecting-to-workspaces

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

