### PR TITLE
GCP: fix copy (no) overwrite semantics

### DIFF
--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -32,8 +32,8 @@ use crate::multipart::PartId;
 use crate::path::Path;
 use crate::util::hex_encode;
 use crate::{
-    Attribute, Attributes, ClientOptions, GetOptions, MultipartId, PutMode, PutMultipartOptions,
-    PutOptions, PutPayload, PutResult, Result, RetryConfig,
+    Attribute, Attributes, ClientOptions, CopyMode, GetOptions, MultipartId, PutMode,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, RetryConfig,
 };
 use async_trait::async_trait;
 use base64::Engine;
@@ -566,12 +566,7 @@ impl GoogleCloudStorageClient {
     }
 
     /// Perform a copy request <https://cloud.google.com/storage/docs/xml-api/put-object-copy>
-    pub(crate) async fn copy_request(
-        &self,
-        from: &Path,
-        to: &Path,
-        if_not_exists: bool,
-    ) -> Result<()> {
+    pub(crate) async fn copy_request(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
         let credential = self.get_credential().await?;
         let url = self.object_url(to);
 
@@ -582,6 +577,11 @@ impl GoogleCloudStorageClient {
             .client
             .request(Method::PUT, url)
             .header("x-goog-copy-source", source);
+
+        let if_not_exists = match mode {
+            CopyMode::Create => true,
+            CopyMode::Overwrite => false,
+        };
 
         if if_not_exists {
             builder = builder.header(&VERSION_MATCH, 0);

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -37,10 +37,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::CopyOptions;
 use crate::client::CredentialProvider;
 use crate::gcp::credential::GCSAuthorizer;
 use crate::signer::Signer;
-use crate::{CopyMode, CopyOptions};
 use crate::{
     GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, UploadPart, multipart::PartId,
@@ -221,10 +221,7 @@ impl ObjectStore for GoogleCloudStorage {
             extensions: _,
         } = options;
 
-        match mode {
-            CopyMode::Overwrite => self.client.copy_request(from, to, true).await,
-            CopyMode::Create => self.client.copy_request(from, to, false).await,
-        }
+        self.client.copy_request(from, to, mode).await
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes #712

# Rationale for this change
 
On `main`, `GoogleCloudStorage::copy(src, dst)` fails with `Error::AlreadyExists` if `dst` is the path to an existing object. This is the wrong default behavior - CopyMode defaults to Overwrite, not Create. This happens because of a bug in `GoogleCloudStorage::copy_opts`, where CopyMode::Overwrite gets mapped to `if_not_exists = true` instead of `false`. 


# What changes are included in this PR?
This PR fixes and moves the boolean mapping closest to where it gets used, to minimise confusion.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes. Anyone using GoogleCloudStorage::copy today who is relying on the incorrect behavior will see objects getting overwritten instead of an error. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
