### PR TITLE
feat(azure): expose `split_sas` for custom SAS credential providers

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -1074,7 +1074,8 @@ fn url_from_env(env_name: &str, default_url: &str) -> Result<Url> {
     Ok(url)
 }
 
-fn split_sas(sas: &str) -> Result<Vec<(String, String)>, Error> {
+/// Parse a SAS token string into the query pairs expected by [`AzureCredential::SASToken`].
+pub fn split_sas(sas: &str) -> Result<Vec<(String, String)>> {
     let sas = percent_decode_str(sas)
         .decode_utf8()
         .map_err(|source| Error::DecodeSasKey { source })?;
@@ -1271,6 +1272,27 @@ mod tests {
         ];
         let pairs = split_sas(raw_sas).unwrap();
         assert_eq!(expected, pairs);
+    }
+
+    #[test]
+    fn azure_test_split_sas_trims_leading_question_mark_and_skips_empties() {
+        let pairs = split_sas("?&sv=2021-10-04& &sp=r").unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                ("sv".to_string(), "2021-10-04".to_string()),
+                ("sp".to_string(), "r".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn azure_test_split_sas_rejects_missing_equals() {
+        let err = split_sas("sv=2021-10-04&bogus").unwrap_err();
+        assert!(
+            err.to_string().contains("Missing component"),
+            "unexpected error: {err}",
+        );
     }
 
     #[test]

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -53,7 +53,7 @@ pub type AzureCredentialProvider = Arc<dyn CredentialProvider<Credential = Azure
 use crate::azure::client::AzureClient;
 use crate::client::parts::Parts;
 use crate::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
-pub use builder::{AzureConfigKey, MicrosoftAzureBuilder};
+pub use builder::{AzureConfigKey, MicrosoftAzureBuilder, split_sas};
 pub use credential::AzureCredential;
 
 const STORE: &str = "MicrosoftAzure";


### PR DESCRIPTION
# Which issue does this PR close?
Closes #720.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
 Users implementing their own `CredentialProvider<Credential = AzureCredential>` that fetches SAS tokens at request time (e.g. tokens refreshed from a secret manager or coordination service) currently have to reimplement this parser to feed pairs into
`AzureCredential::SASToken`. Reimplementations are easy to get subtly wrong: in particular, using `form_urlencoded` decodes `+` as space, which corrupts base64-encoded SAS signatures.

Make `split_sas` public, change its return type to the public `crate::Result<Vec<(String, String)>>` (the inner `Error` variants already convert into `crate::Error` via the existing `From` impl, so the two existing internal call sites are unchanged), document it, and re-export it from `object_store::azure`. Add tests for the empty/`?` edge cases and the missing-`=` error path.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Plumbing to make `split_sas` public and additional test coverage. I tried to keep changes minimal - let me know if a broader API change is needed here, instead of a free function export.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
