### PR TITLE
feat: Support custom DNS resolver

### DIFF
--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -17,15 +17,10 @@
 
 //! Customizable DNS resolution for remote object stores
 
-use std::net::ToSocketAddrs;
-
-use rand::prelude::SliceRandom;
 use std::fmt::Debug;
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 use std::pin::Pin;
-use std::sync::Arc;
-use tokio::task::JoinSet;
 
 /// Error returned by a [`DnsResolver`]
 pub type DnsError = Box<dyn std::error::Error + Send + Sync>;
@@ -43,7 +38,7 @@ pub type DnsFuture = Pin<Box<dyn Future<Output = Result<Vec<IpAddr>, DnsError>> 
 /// HTTP transport.
 ///
 /// Configure via [`ClientOptions::with_dns_resolver`]. The built-in
-/// [`reqwest`]-based transport honors this automatically; custom
+/// reqwest-based transport honors this automatically; custom
 /// [`HttpConnector`] implementations should retrieve it via
 /// [`ClientOptions::dns_resolver`] and apply it themselves.
 ///
@@ -60,56 +55,68 @@ pub trait DnsResolver: Debug + Send + Sync {
     fn resolve(&self, host: &str) -> DnsFuture;
 }
 
-/// Adapts a [`DnsResolver`] to [`reqwest::dns::Resolve`]
-///
-/// This is deliberately private: it is the only place where [`reqwest`]'s
-/// resolver API appears, keeping it out of this crate's public interface.
-pub(crate) struct ReqwestResolver(pub(crate) Arc<dyn DnsResolver>);
+#[cfg(feature = "reqwest")]
+mod reqwest_impl {
+    use super::{DnsError, DnsFuture, DnsResolver};
+    use rand::prelude::SliceRandom;
+    use std::net::{SocketAddr, ToSocketAddrs};
+    use std::sync::Arc;
+    use tokio::task::JoinSet;
 
-impl reqwest::dns::Resolve for ReqwestResolver {
-    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
-        let resolver = Arc::clone(&self.0);
-        let host = name.as_str().to_string();
-        Box::pin(async move {
-            let ips = resolver.resolve(&host).await?;
-            // Port 0 is a placeholder: reqwest documents that it is replaced
-            // by the port from the URL or the scheme's conventional port
-            let addrs: reqwest::dns::Addrs =
-                Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)));
-            Ok(addrs)
-        })
-    }
-}
+    /// Adapts a [`DnsResolver`] to [`reqwest::dns::Resolve`]
+    ///
+    /// This is deliberately private: it is the only place where [`reqwest`]'s
+    /// resolver API appears, keeping it out of this crate's public interface.
+    pub(crate) struct ReqwestResolver(pub(crate) Arc<dyn DnsResolver>);
 
-/// The built-in shuffling [`DnsResolver`], randomizing the order of the returned
-/// addresses to spread load across servers, see [`ClientConfigKey::RandomizeAddresses`]
-///
-/// [`ClientConfigKey::RandomizeAddresses`]: crate::ClientConfigKey::RandomizeAddresses
-#[derive(Debug)]
-pub(crate) struct ShuffleResolver;
-
-impl DnsResolver for ShuffleResolver {
-    fn resolve(&self, host: &str) -> DnsFuture {
-        let host = host.to_string();
-        Box::pin(async move {
-            // use `JoinSet` to propagate cancellation to tasks that haven't started running yet.
-            let mut tasks = JoinSet::new();
-            tasks.spawn_blocking(move || {
-                let it = (host.as_str(), 0).to_socket_addrs()?;
-                let mut addrs = it.map(|addr| addr.ip()).collect::<Vec<_>>();
-                addrs.shuffle(&mut rand::rng());
+    impl reqwest::dns::Resolve for ReqwestResolver {
+        fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+            let resolver = Arc::clone(&self.0);
+            let host = name.as_str().to_string();
+            Box::pin(async move {
+                let ips = resolver.resolve(&host).await?;
+                // Port 0 is a placeholder: reqwest documents that it is replaced
+                // by the port from the URL or the scheme's conventional port
+                let addrs: reqwest::dns::Addrs =
+                    Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)));
                 Ok(addrs)
-            });
-            tasks
-                .join_next()
-                .await
-                .expect("spawned one task")
-                .map_err(|err| Box::new(err) as DnsError)?
-        })
+            })
+        }
+    }
+
+    /// The built-in shuffling [`DnsResolver`], randomizing the order of the returned
+    /// addresses to spread load across servers, see [`ClientConfigKey::RandomizeAddresses`]
+    ///
+    /// [`ClientConfigKey::RandomizeAddresses`]: crate::ClientConfigKey::RandomizeAddresses
+    #[derive(Debug)]
+    pub(crate) struct ShuffleResolver;
+
+    impl DnsResolver for ShuffleResolver {
+        fn resolve(&self, host: &str) -> DnsFuture {
+            let host = host.to_string();
+            Box::pin(async move {
+                // use `JoinSet` to propagate cancellation to tasks that haven't started running yet.
+                let mut tasks = JoinSet::new();
+                tasks.spawn_blocking(move || {
+                    let it = (host.as_str(), 0).to_socket_addrs()?;
+                    let mut addrs = it.map(|addr| addr.ip()).collect::<Vec<_>>();
+                    addrs.shuffle(&mut rand::rng());
+                    Ok(addrs)
+                });
+                tasks
+                    .join_next()
+                    .await
+                    .expect("spawned one task")
+                    .map_err(|err| Box::new(err) as DnsError)?
+            })
+        }
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "reqwest")]
+pub(crate) use reqwest_impl::{ReqwestResolver, ShuffleResolver};
+
+#[cfg(all(test, feature = "reqwest"))]
 mod tests {
     use super::*;
 
@@ -132,6 +139,7 @@ mod tests {
     #[tokio::test]
     async fn adapter_propagates_errors() {
         use reqwest::dns::Resolve;
+        use std::sync::Arc;
         let adapter = ReqwestResolver(Arc::new(FailingResolver));
         let err = match adapter.resolve("localhost".parse().unwrap()).await {
             Ok(_) => panic!("expected resolution to fail"),

--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -15,36 +15,128 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Customizable DNS resolution for remote object stores
+
 use std::net::ToSocketAddrs;
 
 use rand::prelude::SliceRandom;
-use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use std::fmt::Debug;
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
 use tokio::task::JoinSet;
 
-type DynErr = Box<dyn std::error::Error + Send + Sync>;
+/// Error returned by a [`DnsResolver`]
+pub type DnsError = Box<dyn std::error::Error + Send + Sync>;
 
+/// Future returned by [`DnsResolver::resolve`]
+// NOTE: the use cases requiring SocketAddr over IpAddr (i.e., resolver-supplied ports
+// and IPv6 scope IDs) do not apply to object_store, where the port is always
+// determined by the endpoint URL/scheme and endpoints are never link-local.
+pub type DnsFuture = Pin<Box<dyn Future<Output = Result<Vec<IpAddr>, DnsError>> + Send>>;
+
+/// A custom DNS resolver used when establishing connections to remote object stores
+///
+/// This can be used to implement custom resolution logic such as caching,
+/// address shuffling, or split-horizon DNS, independent of the underlying
+/// HTTP transport.
+///
+/// Configure via [`ClientOptions::with_dns_resolver`]. The built-in
+/// [`reqwest`]-based transport honors this automatically; custom
+/// [`HttpConnector`] implementations should retrieve it via
+/// [`ClientOptions::dns_resolver`] and apply it themselves.
+///
+/// [`ClientOptions::with_dns_resolver`]: crate::ClientOptions::with_dns_resolver
+/// [`ClientOptions::dns_resolver`]: crate::ClientOptions::dns_resolver
+/// [`HttpConnector`]: crate::client::HttpConnector
+pub trait DnsResolver: Debug + Send + Sync {
+    /// Resolve `host` to one or more IP addresses
+    ///
+    /// The returned addresses are tried in order until a connection succeeds,
+    /// so implementations are responsible for any ordering they require, e.g.
+    /// shuffling or interleaving of address families. The port is determined
+    /// by the transport from the URL, not by the resolver.
+    fn resolve(&self, host: &str) -> DnsFuture;
+}
+
+/// Adapts a [`DnsResolver`] to [`reqwest::dns::Resolve`]
+///
+/// This is deliberately private: it is the only place where [`reqwest`]'s
+/// resolver API appears, keeping it out of this crate's public interface.
+pub(crate) struct ReqwestResolver(pub(crate) Arc<dyn DnsResolver>);
+
+impl reqwest::dns::Resolve for ReqwestResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let resolver = Arc::clone(&self.0);
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let ips = resolver.resolve(&host).await?;
+            // Port 0 is a placeholder: reqwest documents that it is replaced
+            // by the port from the URL or the scheme's conventional port
+            let addrs: reqwest::dns::Addrs =
+                Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+            Ok(addrs)
+        })
+    }
+}
+
+/// The built-in shuffling [`DnsResolver`], randomizing the order of the returned
+/// addresses to spread load across servers, see [`ClientConfigKey::RandomizeAddresses`]
+///
+/// [`ClientConfigKey::RandomizeAddresses`]: crate::ClientConfigKey::RandomizeAddresses
 #[derive(Debug)]
 pub(crate) struct ShuffleResolver;
 
-impl Resolve for ShuffleResolver {
-    fn resolve(&self, name: Name) -> Resolving {
+impl DnsResolver for ShuffleResolver {
+    fn resolve(&self, host: &str) -> DnsFuture {
+        let host = host.to_string();
         Box::pin(async move {
-            // use `JoinSet` to propagate cancelation to tasks that haven't started running yet.
+            // use `JoinSet` to propagate cancellation to tasks that haven't started running yet.
             let mut tasks = JoinSet::new();
             tasks.spawn_blocking(move || {
-                let it = (name.as_str(), 0).to_socket_addrs()?;
-                let mut addrs = it.collect::<Vec<_>>();
-
+                let it = (host.as_str(), 0).to_socket_addrs()?;
+                let mut addrs = it.map(|addr| addr.ip()).collect::<Vec<_>>();
                 addrs.shuffle(&mut rand::rng());
-
-                Ok(Box::new(addrs.into_iter()) as Addrs)
+                Ok(addrs)
             });
-
             tasks
                 .join_next()
                 .await
-                .expect("spawned on task")
-                .map_err(|err| Box::new(err) as DynErr)?
+                .expect("spawned one task")
+                .map_err(|err| Box::new(err) as DnsError)?
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shuffle_resolver_resolves_localhost() {
+        let ips = ShuffleResolver.resolve("localhost").await.unwrap();
+        assert!(!ips.is_empty());
+        assert!(ips.iter().all(|ip| ip.is_loopback()));
+    }
+
+    #[derive(Debug)]
+    struct FailingResolver;
+
+    impl DnsResolver for FailingResolver {
+        fn resolve(&self, _host: &str) -> DnsFuture {
+            Box::pin(async { Err("boom".into()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_propagates_errors() {
+        use reqwest::dns::Resolve;
+        let adapter = ReqwestResolver(Arc::new(FailingResolver));
+        let err = match adapter.resolve("localhost".parse().unwrap()).await {
+            Ok(_) => panic!("expected resolution to fail"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("boom"));
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,7 +21,7 @@
 
 pub(crate) mod backoff;
 
-#[cfg(all(feature = "reqwest", not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 mod dns;
 #[cfg(not(target_arch = "wasm32"))]
 pub use dns::{DnsError, DnsFuture, DnsResolver};
@@ -63,9 +63,6 @@ pub use crypto::*;
 
 use ::http::header::{HeaderMap, HeaderValue};
 use async_trait::async_trait;
-//kdn KEEP?
-use reqwest::dns::Resolve;
-use reqwest::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -409,6 +406,7 @@ impl Default for ClientOptions {
             http1_only: true.into(),
             http2_only: Default::default(),
             randomize_addresses: true.into(),
+            #[cfg(not(target_arch = "wasm32"))]
             dns_resolver: Default::default(),
         }
     }
@@ -1304,6 +1302,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(all(feature = "reqwest", not(target_arch = "wasm32")))]
     async fn test_custom_dns_resolver() {
         use crate::client::mock_server::MockServer;
         use std::net::{IpAddr, Ipv4Addr};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod backoff;
 
 #[cfg(all(feature = "reqwest", not(target_arch = "wasm32")))]
 mod dns;
+#[cfg(not(target_arch = "wasm32"))]
+pub use dns::{DnsError, DnsFuture, DnsResolver};
 
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
@@ -339,14 +341,6 @@ impl Certificate {
     }
 }
 
-#[derive(Clone)]
-struct DynResolver(Arc<dyn Resolve>);
-
-impl std::fmt::Debug for DynResolver {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("DynResolver")
-    }
-}
 /// HTTP client configuration for remote object stores
 #[derive(Debug, Clone)]
 pub struct ClientOptions {
@@ -374,7 +368,8 @@ pub struct ClientOptions {
     http1_only: ConfigValue<bool>,
     http2_only: ConfigValue<bool>,
     randomize_addresses: ConfigValue<bool>,
-    dns_resolver: Option<DynResolver>,
+    #[cfg(not(target_arch = "wasm32"))]
+    dns_resolver: Option<Arc<dyn DnsResolver>>,
 }
 
 impl Default for ClientOptions {
@@ -809,13 +804,30 @@ impl ClientOptions {
         self
     }
 
-    /// Override the default DNS resolver with a custom [`reqwest::dns::Resolve`] implementation.
+    /// Override the default DNS resolution with a custom [`DnsResolver`]
     ///
-    /// When set, [`ClientConfigKey::RandomizeAddresses`] will be ignored. The provided
-    /// resolver is responsible for resolving, shuffling, caching, etc.
-    pub fn with_dns_resolver(mut self, resolver: Arc<dyn Resolve>) -> Self {
-        self.dns_resolver = Some(DynResolver(resolver));
+    /// When set, [`ClientConfigKey::RandomizeAddresses`] is ignored: the
+    /// provided resolver is fully responsible for resolution, ordering,
+    /// shuffling, and caching.
+    ///
+    /// The built-in reqwest-based transport applies this automatically.
+    /// Custom [`HttpConnector`] implementations should read it via
+    /// [`Self::dns_resolver`] and honor it.
+    ///
+    /// Note: unlike other options, this cannot be configured via
+    /// [`ClientConfigKey`] / string configuration.
+    ///
+    /// [`HttpConnector`]: crate::client::HttpConnector
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_dns_resolver(mut self, resolver: Arc<dyn DnsResolver>) -> Self {
+        self.dns_resolver = Some(resolver);
         self
+    }
+
+    /// Return the custom [`DnsResolver`] if any, see [`Self::with_dns_resolver`]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn dns_resolver(&self) -> Option<&Arc<dyn DnsResolver>> {
+        self.dns_resolver.as_ref()
     }
 
     /// Get the default headers defined through `ClientOptions::with_default_headers`
@@ -950,10 +962,13 @@ impl ClientOptions {
         // size of objects.
         builder = builder.no_gzip().no_brotli().no_zstd().no_deflate();
 
-        if let Some(resolver) = &self.dns_resolver {
-            builder = builder.dns_resolver2(resolver.0.clone());
-        } else if self.randomize_addresses.get()? {
-            builder = builder.dns_resolver(Arc::new(dns::ShuffleResolver));
+        let resolver: Option<Arc<dyn DnsResolver>> = match &self.dns_resolver {
+            Some(resolver) => Some(Arc::clone(resolver)),
+            None if self.randomize_addresses.get()? => Some(Arc::new(dns::ShuffleResolver)),
+            None => None,
+        };
+        if let Some(resolver) = resolver {
+            builder = builder.dns_resolver(Arc::new(dns::ReqwestResolver(resolver)));
         }
 
         builder
@@ -1286,5 +1301,40 @@ mod tests {
                 .unwrap(),
             user_agent
         );
+    }
+
+    #[tokio::test]
+    async fn test_custom_dns_resolver() {
+        use crate::client::mock_server::MockServer;
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Debug, Default)]
+        struct CountingResolver(AtomicUsize);
+
+        impl DnsResolver for CountingResolver {
+            fn resolve(&self, host: &str) -> DnsFuture {
+                assert_eq!(host, "localhost");
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Ok(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]) })
+            }
+        }
+
+        let server = MockServer::new().await;
+        server.push(::http::Response::new("hello".to_string()));
+
+        let resolver = Arc::new(CountingResolver::default());
+        let client = ClientOptions::new()
+            .with_allow_http(true)
+            .with_dns_resolver(Arc::clone(&resolver) as Arc<dyn DnsResolver>)
+            .client()
+            .unwrap();
+
+        // Use a hostname (not an IP literal) so resolution actually runs
+        let parsed = url::Url::parse(server.url()).unwrap();
+        let url = format!("http://localhost:{}/", parsed.port().unwrap());
+        let resp = client.get(url).send().await.unwrap();
+        assert!(resp.status().is_success());
+        assert_eq!(resolver.0.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -61,6 +61,9 @@ pub use crypto::*;
 
 use ::http::header::{HeaderMap, HeaderValue};
 use async_trait::async_trait;
+//kdn KEEP?
+use reqwest::dns::Resolve;
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -336,6 +339,14 @@ impl Certificate {
     }
 }
 
+#[derive(Clone)]
+struct DynResolver(Arc<dyn Resolve>);
+
+impl std::fmt::Debug for DynResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DynResolver")
+    }
+}
 /// HTTP client configuration for remote object stores
 #[derive(Debug, Clone)]
 pub struct ClientOptions {
@@ -363,6 +374,7 @@ pub struct ClientOptions {
     http1_only: ConfigValue<bool>,
     http2_only: ConfigValue<bool>,
     randomize_addresses: ConfigValue<bool>,
+    dns_resolver: Option<DynResolver>,
 }
 
 impl Default for ClientOptions {
@@ -402,6 +414,7 @@ impl Default for ClientOptions {
             http1_only: true.into(),
             http2_only: Default::default(),
             randomize_addresses: true.into(),
+            dns_resolver: Default::default(),
         }
     }
 }
@@ -796,6 +809,15 @@ impl ClientOptions {
         self
     }
 
+    /// Override the default DNS resolver with a custom [`reqwest::dns::Resolve`] implementation.
+    ///
+    /// When set, [`ClientConfigKey::RandomizeAddresses`] will be ignored. The provided
+    /// resolver is responsible for resolving, shuffling, caching, etc.
+    pub fn with_dns_resolver(mut self, resolver: Arc<dyn Resolve>) -> Self {
+        self.dns_resolver = Some(DynResolver(resolver));
+        self
+    }
+
     /// Get the default headers defined through `ClientOptions::with_default_headers`
     pub fn get_default_headers(&self) -> Option<&HeaderMap> {
         self.default_headers.as_ref()
@@ -928,7 +950,9 @@ impl ClientOptions {
         // size of objects.
         builder = builder.no_gzip().no_brotli().no_zstd().no_deflate();
 
-        if self.randomize_addresses.get()? {
+        if let Some(resolver) = &self.dns_resolver {
+            builder = builder.dns_resolver2(resolver.0.clone());
+        } else if self.randomize_addresses.get()? {
             builder = builder.dns_resolver(Arc::new(dns::ShuffleResolver));
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

Mitigates but does not close #726.

# Rationale for this change
 
This PR enables users of object_store to provide a custom DNS resolver. Use case: the custom DNS resolver may have different properties (e.g., caching), and a different footprint (e.g., substantially smaller) than the default options.

# What changes are included in this PR?

Enables override of the DNS resolver as used by the `reqwest::HttpClient`.

# Are there any user-facing changes?

Yes. This PR adds `ClientOptions::with_dns_resolver(Arc<dyn reqwest::dns::Resolve>)`.
