### PR TITLE
Add Azure option to skip invalid list paths

### DIFF
--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -170,6 +170,8 @@ pub struct MicrosoftAzureBuilder {
     use_fabric_endpoint: ConfigValue<bool>,
     /// When set to true, skips tagging objects
     disable_tagging: ConfigValue<bool>,
+    /// When set to true, skips invalid paths returned by list operations
+    skip_invalid_paths: ConfigValue<bool>,
     /// Fabric token service url
     fabric_token_service_url: Option<String>,
     /// Fabric workload host
@@ -352,6 +354,13 @@ pub enum AzureConfigKey {
     /// - `disable_tagging`
     DisableTagging,
 
+    /// Skips invalid paths returned by list operations
+    ///
+    /// Supported keys:
+    /// - `azure_skip_invalid_paths`
+    /// - `skip_invalid_paths`
+    SkipInvalidPaths,
+
     /// Fabric token service url
     ///
     /// Supported keys:
@@ -406,6 +415,7 @@ impl AsRef<str> for AzureConfigKey {
             Self::SkipSignature => "azure_skip_signature",
             Self::ContainerName => "azure_container_name",
             Self::DisableTagging => "azure_disable_tagging",
+            Self::SkipInvalidPaths => "azure_skip_invalid_paths",
             Self::FabricTokenServiceUrl => "azure_fabric_token_service_url",
             Self::FabricWorkloadHost => "azure_fabric_workload_host",
             Self::FabricSessionToken => "azure_fabric_session_token",
@@ -458,6 +468,7 @@ impl FromStr for AzureConfigKey {
             "azure_skip_signature" | "skip_signature" => Ok(Self::SkipSignature),
             "azure_container_name" | "container_name" => Ok(Self::ContainerName),
             "azure_disable_tagging" | "disable_tagging" => Ok(Self::DisableTagging),
+            "azure_skip_invalid_paths" | "skip_invalid_paths" => Ok(Self::SkipInvalidPaths),
             "azure_fabric_token_service_url" | "fabric_token_service_url" => {
                 Ok(Self::FabricTokenServiceUrl)
             }
@@ -586,6 +597,7 @@ impl MicrosoftAzureBuilder {
             }
             AzureConfigKey::ContainerName => self.container_name = Some(value.into()),
             AzureConfigKey::DisableTagging => self.disable_tagging.parse(value),
+            AzureConfigKey::SkipInvalidPaths => self.skip_invalid_paths.parse(value),
             AzureConfigKey::FabricTokenServiceUrl => {
                 self.fabric_token_service_url = Some(value.into())
             }
@@ -631,6 +643,7 @@ impl MicrosoftAzureBuilder {
             AzureConfigKey::Client(key) => self.client_options.get_config_value(key),
             AzureConfigKey::ContainerName => self.container_name.clone(),
             AzureConfigKey::DisableTagging => Some(self.disable_tagging.to_string()),
+            AzureConfigKey::SkipInvalidPaths => Some(self.skip_invalid_paths.to_string()),
             AzureConfigKey::FabricTokenServiceUrl => self.fabric_token_service_url.clone(),
             AzureConfigKey::FabricWorkloadHost => self.fabric_workload_host.clone(),
             AzureConfigKey::FabricSessionToken => self.fabric_session_token.clone(),
@@ -898,6 +911,13 @@ impl MicrosoftAzureBuilder {
         self
     }
 
+    /// If set to `true`, listing operations will skip objects and prefixes
+    /// whose names cannot be parsed as [`crate::Path`].
+    pub fn with_skip_invalid_paths(mut self, skip_invalid_paths: bool) -> Self {
+        self.skip_invalid_paths = skip_invalid_paths.into();
+        self
+    }
+
     /// The [`HttpConnector`] to use
     ///
     /// On non-WASM32 platforms uses [`reqwest`] by default, on WASM32 platforms must be provided
@@ -1045,6 +1065,7 @@ impl MicrosoftAzureBuilder {
             skip_signature: self.skip_signature.get()?,
             container,
             disable_tagging: self.disable_tagging.get()?,
+            skip_invalid_paths: self.skip_invalid_paths.get()?,
             retry_config: self.retry_config,
             client_options: self.client_options,
             service: storage_url,
@@ -1243,6 +1264,7 @@ mod tests {
             ("azure_client_id", azure_client_id),
             ("azure_storage_account_name", azure_storage_account_name),
             ("azure_storage_token", azure_storage_token),
+            ("azure_skip_invalid_paths", "true"),
         ]);
 
         let builder = options
@@ -1253,6 +1275,7 @@ mod tests {
         assert_eq!(builder.client_id.unwrap(), azure_client_id);
         assert_eq!(builder.account_name.unwrap(), azure_storage_account_name);
         assert_eq!(builder.bearer_token.unwrap(), azure_storage_token);
+        assert!(builder.skip_invalid_paths.get().unwrap());
     }
 
     #[test]

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -166,6 +166,7 @@ pub(crate) struct AzureConfig {
     pub is_emulator: bool,
     pub skip_signature: bool,
     pub disable_tagging: bool,
+    pub skip_invalid_paths: bool,
     pub client_options: ClientOptions,
 }
 
@@ -1008,7 +1009,7 @@ impl ListClient for Arc<AzureClient> {
         }
 
         Ok(PaginatedListResult {
-            result: to_list_result(response, prefix)?,
+            result: to_list_result(response, prefix, self.config.skip_invalid_paths)?,
             page_token: token,
         })
     }
@@ -1025,13 +1026,17 @@ struct ListResultInternal {
     pub blobs: Blobs,
 }
 
-fn to_list_result(value: ListResultInternal, prefix: Option<&str>) -> Result<ListResult> {
+fn to_list_result(
+    value: ListResultInternal,
+    prefix: Option<&str>,
+    skip_invalid_paths: bool,
+) -> Result<ListResult> {
     let prefix = prefix.unwrap_or_default();
     let common_prefixes = value
         .blobs
         .blob_prefix
         .into_iter()
-        .map(|x| Ok(Path::parse(x.name)?))
+        .filter_map(|x| parse_list_path(x.name, skip_invalid_paths).transpose())
         .collect::<Result<_>>()?;
 
     let objects = value
@@ -1045,13 +1050,21 @@ fn to_list_result(value: ListResultInternal, prefix: Option<&str>) -> Result<Lis
             !matches!(blob.properties.resource_type.as_ref(), Some(typ) if typ == "directory")
                 && blob.name.len() > prefix.len()
         })
-        .map(ObjectMeta::try_from)
+        .filter_map(|blob| blob_to_object_meta(blob, skip_invalid_paths).transpose())
         .collect::<Result<_>>()?;
 
     Ok(ListResult {
         common_prefixes,
         objects,
     })
+}
+
+fn parse_list_path(path: String, skip_invalid_paths: bool) -> Result<Option<Path>> {
+    match Path::parse(path) {
+        Ok(path) => Ok(Some(path)),
+        Err(_) if skip_invalid_paths => Ok(None),
+        Err(source) => Err(source.into()),
+    }
 }
 
 /// Collection of blobs and potentially shared prefixes returned from list requests.
@@ -1087,14 +1100,26 @@ impl TryFrom<Blob> for ObjectMeta {
     type Error = crate::Error;
 
     fn try_from(value: Blob) -> Result<Self> {
-        Ok(Self {
-            location: Path::parse(value.name)?,
-            last_modified: value.properties.last_modified,
-            size: value.properties.content_length,
-            e_tag: value.properties.e_tag,
-            version: None, // For consistency with S3 and GCP which don't include this
-        })
+        match blob_to_object_meta(value, false)? {
+            Some(meta) => Ok(meta),
+            None => unreachable!("invalid paths are not skipped"),
+        }
     }
+}
+
+fn blob_to_object_meta(value: Blob, skip_invalid_paths: bool) -> Result<Option<ObjectMeta>> {
+    let location = match parse_list_path(value.name, skip_invalid_paths)? {
+        Some(location) => location,
+        None => return Ok(None),
+    };
+
+    Ok(Some(ObjectMeta {
+        location,
+        last_modified: value.properties.last_modified,
+        size: value.properties.content_length,
+        e_tag: value.properties.e_tag,
+        version: None, // For consistency with S3 and GCP which don't include this
+    }))
 }
 
 /// Properties associated with individual blobs. The actual list
@@ -1184,6 +1209,60 @@ mod tests {
     use bytes::Bytes;
     use regex::bytes::Regex;
     use reqwest::Client;
+
+    fn list_response_with_invalid_paths() -> ListResultInternal {
+        const S: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<EnumerationResults ServiceEndpoint=\"https://account.blob.core.windows.net/\" ContainerName=\"container\">
+    <Blobs>
+        <BlobPrefix>
+            <Name>valid-prefix/</Name>
+        </BlobPrefix>
+        <BlobPrefix>
+            <Name>invalid//prefix/</Name>
+        </BlobPrefix>
+        <Blob>
+            <Name>valid.txt</Name>
+            <Properties>
+                <Last-Modified>Thu, 01 Jul 2021 10:44:59 GMT</Last-Modified>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+            </Properties>
+        </Blob>
+        <Blob>
+            <Name>invalid//blob.txt</Name>
+            <Properties>
+                <Last-Modified>Thu, 01 Jul 2021 10:44:59 GMT</Last-Modified>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+            </Properties>
+        </Blob>
+    </Blobs>
+    <NextMarker />
+</EnumerationResults>";
+
+        quick_xml::de::from_str(S).unwrap()
+    }
+
+    #[test]
+    fn list_result_errors_on_invalid_paths_by_default() {
+        let err = to_list_result(list_response_with_invalid_paths(), None, false).unwrap_err();
+        assert!(err.to_string().contains("empty path segment"));
+    }
+
+    #[test]
+    fn list_result_can_skip_invalid_paths() {
+        let result = to_list_result(list_response_with_invalid_paths(), None, true).unwrap();
+
+        assert_eq!(
+            result.common_prefixes,
+            vec![Path::parse("valid-prefix").unwrap()]
+        );
+        assert_eq!(result.objects.len(), 1);
+        assert_eq!(
+            result.objects[0].location,
+            Path::parse("valid.txt").unwrap()
+        );
+    }
 
     #[test]
     fn deserde_azure() {
@@ -1389,6 +1468,7 @@ mod tests {
             is_emulator: false,
             skip_signature: false,
             disable_tagging: false,
+            skip_invalid_paths: false,
             client_options: Default::default(),
         };
 


### PR DESCRIPTION
Closes #341.

Adds an Azure builder/config option to skip list entries whose returned names are not valid object_store paths. The default behavior is unchanged and still returns an error.

Checks:
- cargo fmt --check
- cargo test --features azure azure::client::tests --lib
- cargo test --features azure azure::builder::tests --lib
- cargo clippy --features azure --lib -- -D warnings
- git diff --check