### PR TITLE
Support custom S3 conditional put headers

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -199,6 +199,17 @@ impl ObjectStore for AmazonS3 {
                     r => r,
                 }
             }
+            (PutMode::Create, S3ConditionalPut::Header(k, v)) => {
+                match request.header(k, v).do_put().await {
+                    Err(e @ Error::NotModified { .. } | e @ Error::Precondition { .. }) => {
+                        Err(Error::AlreadyExists {
+                            path: location.to_string(),
+                            source: Box::new(e),
+                        })
+                    }
+                    r => r,
+                }
+            }
             (PutMode::Update(v), put) => {
                 let etag = v.e_tag.ok_or_else(|| Error::Generic {
                     store: STORE,
@@ -229,6 +240,12 @@ impl ObjectStore for AmazonS3 {
                     S3ConditionalPut::Disabled => Err(Error::NotImplemented {
                         operation:
                             "`put_opts` with mode `PutMode::Update` when conditional put is disabled"
+                                .into(),
+                        implementer: self.to_string(),
+                    }),
+                    S3ConditionalPut::Header(_, _) => Err(Error::NotImplemented {
+                        operation:
+                            "`put_opts` with mode `PutMode::Update` when conditional put uses a custom header"
                                 .into(),
                         implementer: self.to_string(),
                     }),
@@ -517,14 +534,79 @@ mod tests {
     use crate::ObjectStoreExt;
     use crate::client::SpawnedReqwestConnector;
     use crate::client::get::GetClient;
+    use crate::client::mock_server::MockServer;
     use crate::client::retry::RetryContext;
     use crate::integration::*;
     use crate::tests::*;
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
     use http::HeaderMap;
+    use http::Response;
 
     const NON_EXISTENT_NAME: &str = "nonexistentname";
+
+    fn mock_s3_store(mock: &MockServer, conditional_put: S3ConditionalPut) -> AmazonS3 {
+        AmazonS3Builder::new()
+            .with_bucket_name("bucket")
+            .with_region("us-east-1")
+            .with_endpoint(mock.url().to_string())
+            .with_allow_http(true)
+            .with_skip_signature(true)
+            .with_conditional_put(conditional_put)
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn put_create_uses_custom_conditional_header() {
+        let mock = MockServer::new().await;
+        mock.push_fn(|req| {
+            assert_eq!(req.method(), Method::PUT);
+            assert_eq!(req.headers().get("x-oss-forbid-overwrite").unwrap(), "true");
+
+            Response::builder()
+                .status(200)
+                .header("etag", "\"test-etag\"")
+                .body(String::new())
+                .unwrap()
+        });
+
+        let store = mock_s3_store(
+            &mock,
+            S3ConditionalPut::Header("x-oss-forbid-overwrite".into(), "true".into()),
+        );
+
+        store
+            .put_opts(&Path::from("test"), "hello".into(), PutMode::Create.into())
+            .await
+            .unwrap();
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn put_create_custom_conditional_header_conflict_is_already_exists() {
+        let mock = MockServer::new().await;
+        mock.push_fn(|req| {
+            assert_eq!(req.headers().get("x-oss-forbid-overwrite").unwrap(), "true");
+
+            Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(String::new())
+                .unwrap()
+        });
+
+        let store = mock_s3_store(
+            &mock,
+            S3ConditionalPut::Header("x-oss-forbid-overwrite".into(), "true".into()),
+        );
+
+        let err = store
+            .put_opts(&Path::from("test"), "hello".into(), PutMode::Create.into())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::AlreadyExists { .. }));
+        mock.shutdown().await;
+    }
 
     #[tokio::test]
     async fn write_multipart_file_with_signature() {

--- a/src/aws/precondition.rs
+++ b/src/aws/precondition.rs
@@ -127,6 +127,20 @@ pub enum S3ConditionalPut {
     #[default]
     ETagMatch,
 
+    /// Some S3-compatible stores support create-only put semantics through
+    /// custom headers.
+    ///
+    /// If set, [`PutMode::Create`] will perform a normal put operation with the
+    /// provided header pair.
+    ///
+    /// Encoded as `header:<HEADER_NAME>:<HEADER_VALUE>` ignoring whitespace
+    ///
+    /// For example `header: x-oss-forbid-overwrite: true`, would set the header
+    /// `x-oss-forbid-overwrite` to `true`.
+    ///
+    /// [`PutMode::Create`]: crate::PutMode::Create
+    Header(String, String),
+
     /// Disable `conditional put`
     Disabled,
 }
@@ -135,6 +149,7 @@ impl std::fmt::Display for S3ConditionalPut {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ETagMatch => write!(f, "etag"),
+            Self::Header(k, v) => write!(f, "header: {k}: {v}"),
             Self::Disabled => write!(f, "disabled"),
         }
     }
@@ -145,7 +160,16 @@ impl S3ConditionalPut {
         match s.trim() {
             "etag" => Some(Self::ETagMatch),
             "disabled" => Some(Self::Disabled),
-            _ => None,
+            _ => {
+                let (variant, value) = s.split_once(':')?;
+                match variant.trim() {
+                    "header" => {
+                        let (k, v) = value.split_once(':')?;
+                        Some(Self::Header(k.trim().to_string(), v.trim().to_string()))
+                    }
+                    _ => None,
+                }
+            }
         }
     }
 }
@@ -161,7 +185,7 @@ impl Parse for S3ConditionalPut {
 
 #[cfg(test)]
 mod tests {
-    use super::S3CopyIfNotExists;
+    use super::{S3ConditionalPut, S3CopyIfNotExists};
 
     #[test]
     fn parse_s3_copy_if_not_exists_header() {
@@ -228,6 +252,38 @@ mod tests {
 
         for input in INPUTS {
             assert_eq!(expected, S3CopyIfNotExists::from_str(input));
+        }
+    }
+
+    #[test]
+    fn parse_s3_conditional_put_header() {
+        let input = "header: x-oss-forbid-overwrite: true";
+        let expected = Some(S3ConditionalPut::Header(
+            "x-oss-forbid-overwrite".to_owned(),
+            "true".to_owned(),
+        ));
+
+        assert_eq!(expected, S3ConditionalPut::from_str(input));
+    }
+
+    #[test]
+    fn parse_s3_conditional_put_header_whitespace_invariant() {
+        let expected = Some(S3ConditionalPut::Header(
+            "x-oss-forbid-overwrite".to_owned(),
+            "true".to_owned(),
+        ));
+
+        const INPUTS: &[&str] = &[
+            "header:x-oss-forbid-overwrite:true",
+            "header: x-oss-forbid-overwrite:true",
+            "header: x-oss-forbid-overwrite: true",
+            "header : x-oss-forbid-overwrite: true",
+            "header : x-oss-forbid-overwrite : true",
+            "header : x-oss-forbid-overwrite : true ",
+        ];
+
+        for input in INPUTS {
+            assert_eq!(expected, S3ConditionalPut::from_str(input));
         }
     }
 }


### PR DESCRIPTION
Closes #416.

Adds a custom-header mode for S3 conditional puts, so S3-compatible stores can wire `PutMode::Create` to headers such as `x-oss-forbid-overwrite: true`. Conflict responses continue to surface as `AlreadyExists`.

Checks:
- cargo fmt --check
- cargo test --features aws parse_s3_conditional_put_header --lib
- cargo test --features aws put_create_ --lib
- cargo clippy --features aws --lib -- -D warnings
- git diff --check