### PR TITLE
fix(aws): set retry_error_body on bulk_delete_request

### DIFF
--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -578,7 +578,9 @@ impl S3Client {
             .header(CONTENT_TYPE, "application/xml")
             .body(body)
             .with_aws_sigv4(credential.authorizer(), Some(digest.as_ref()))
-            .send_retry(&self.config.retry_config)
+            .retryable(&self.config.retry_config)
+            .retry_error_body(true)
+            .send()
             .await
             .map_err(|source| Error::DeleteObjectsRequest {
                 source,


### PR DESCRIPTION
Closes #277

AWS S3 can return HTTP 200 with a SlowDown or InternalError XML body for DeleteObjects requests. The retry logic already handles this via body_contains_error() when retry_error_body is set, and other requests (copy_part, complete_multipart) already use this flag. bulk_delete_request was missing it, causing throttling errors to surface instead of being retried.

