### PR TITLE
ci: use --locked when installing cargo-msrv and cargo-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -38,6 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
       - name: Run audit check
         run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+        run: cargo install cargo-msrv --locked
       - name: Check
         run: |
           # run `cargo msrv verify` to see problems


### PR DESCRIPTION
## What

Pass `--locked` to the `cargo install` invocations for `cargo-msrv` and `cargo-audit` in CI.

## Why
Observed on https://github.com/apache/arrow-rs-object-store/pull/724 — failing run: https://github.com/apache/arrow-rs-object-store/actions/runs/27380222949/job/80920110172?pr=724

Without `--locked`, `cargo install` ignores the `Cargo.lock` published alongside the tool and re-resolves all transitive dependencies to the latest semver-compatible versions at install time. This can pick up upstream releases that the tool's maintainers never tested against, leading to install failures that have nothing to do with our code.

The MSRV job is currently failing for this reason. `cargo-msrv 0.19.3` transitively depends on the AWS SDK (via `rust-releases`, which fetches the Rust release index from S3). Without `--locked`, cargo resolves `aws-runtime` to `1.7.4`, which does not compile on recent rustc due to a type-inference regression in its SigV4 signer:

```
error[E0282]: type annotations needed
   --> aws-runtime-1.7.4/src/auth/sigv4.rs:278:22
    |
278 |                     .send(Box::new(SigV4MessageSigner::new(
    |                      ^^^^ cannot infer type of the type parameter `T`
```

cargo-msrv's published `Cargo.lock` pins `aws-runtime 1.7.2`, which builds cleanly. `--locked` tells cargo to honor it.

## Test
Tested locally with `cargo install cargo-msrv --locked --force`
