### PR TITLE
refactor!: remove `cloud` feature alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,11 +90,6 @@ cloud-base = ["serde", "serde_json", "quick-xml", "hyper", "chrono/serde", "base
 # Built-in reqwest-based HTTP transport.
 reqwest = ["dep:reqwest", "reqwest/stream"]
 
-# Compatibility/convenience alias.
-# Historically, cloud meant "common cloud support", including reqwest.
-# Keep that behavior for existing users.
-cloud = ["cloud-base", "reqwest"]
-
 # Provider base features.
 # These compile provider logic without forcing reqwest.
 azure-base = ["cloud-base", "httparse"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,7 +554,6 @@
 //! | `reqwest` | Enables the default [`reqwest`]-based [`HttpConnector`]. Pulled in automatically by `aws`, `azure`, `gcp`, and `http`. |
 //! | `tls-webpki-roots` | When `reqwest` is enabled, also bundle Mozilla's [`webpki-roots`] CA certificates. See [TLS Certificates](#tls-certificates). |
 //! | `cloud-base` | Shared cloud-provider implementation. Pulled in automatically by every `*-base` feature; usually not enabled directly. |
-//! | `cloud` | Back-compat alias for `cloud-base` + `reqwest`. Kept for users that previously depended on the `cloud` umbrella feature. |
 //!
 //! ## Other features
 //!


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #744 (and contributes to the 0.14.0 breaking release tracked in #657).

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
`cloud` was a back-compat alias for `cloud-base + reqwest`. Now that #724 introduced `cloud-base`, `*-base`, and an explicit `reqwest` feature, the `cloud` umbrella is redundant and ambiguous. Since 0.14.0 is already a breaking release, drop it cleanly rather than carry a deprecation alias.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Remove `cloud = ["cloud-base", "reqwest"]` from `Cargo.toml`.
- Remove the `cloud` row from the Feature Flags table in `src/lib.rs` docs.
- `cloud-base` and the `*-base` / `aws` / `azure` / `gcp` / `http` features
  are unchanged.

# Are there any user-facing changes?
Yes — breaking. `--features cloud` now fails with `the package 'object_store' does not contain this feature: cloud`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
