### PR TITLE
Use path-style URL in `resolve_bucket_region` for dotted bucket names

### DIFF
--- a/src/aws/resolve.rs
+++ b/src/aws/resolve.rs
@@ -49,7 +49,12 @@ impl From<Error> for crate::Error {
 pub async fn resolve_bucket_region(bucket: &str, client_options: &ClientOptions) -> Result<String> {
     use http::StatusCode;
 
-    let endpoint = format!("https://{bucket}.s3.amazonaws.com");
+    // S3's wildcard TLS cert (*.s3.amazonaws.com) only covers one DNS label. Use path-style for dotted names.
+    let endpoint = if bucket.contains('.') {
+        format!("https://s3.amazonaws.com/{bucket}")
+    } else {
+        format!("https://{bucket}.s3.amazonaws.com")
+    };
 
     let client = client_options.client()?;
 


### PR DESCRIPTION
## Summary

`resolve_bucket_region` unconditionally uses virtual-hosted-style URLs (`{bucket}.s3.amazonaws.com`). When the bucket name contains dots, this produces a hostname that doesn't match S3's `*.s3.amazonaws.com` wildcard TLS certificate (wildcards only cover a single DNS label), causing the TLS handshake to fail.

This PR falls back to path-style (`s3.amazonaws.com/{bucket}`) when the bucket name contains a dot — the same heuristic the official AWS SDKs use.

- Closes #747