### PR TITLE
Support PutMultipartOptions for MultipartStore::create_multipart for AWS/GCP.

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -485,6 +485,14 @@ impl MultipartStore for AmazonS3 {
             .await
     }
 
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        self.client.create_multipart(path, opts).await
+    }
+
     async fn put_part(
         &self,
         path: &Path,
@@ -694,6 +702,7 @@ mod tests {
         rename_and_copy(&integration).await;
         stream_get(&integration).await;
         multipart(&integration, &integration).await;
+        multipart_with_opts(&integration, &integration).await;
         multipart_put_part_out_of_order(&integration, &integration).await;
         multipart_race_condition(&integration, true).await;
         multipart_out_of_order(&integration).await;

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -302,7 +302,7 @@ impl MultipartStore for MicrosoftAzure {
             extensions: _,
         } = opts;
 
-        if tags != Default::default() || attributes != Default::default() {
+        if !tags.is_empty() || !attributes.is_empty() {
             return Err(Error::NotSupported {
                 source: "`create_multipart_opts` with non-default options is not supported by MicrosoftAzure".into(),
             });

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -24,7 +24,7 @@
 //! Unused blocks will automatically be dropped after 7 days.
 //!
 use crate::{
-    CopyMode, CopyOptions, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload,
+    CopyMode, CopyOptions, Error, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload,
     ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
     UploadPart,
     multipart::{MultipartStore, PartId},
@@ -291,6 +291,26 @@ impl MultipartStore for MicrosoftAzure {
         Ok(String::new())
     }
 
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        let PutMultipartOptions {
+            tags,
+            attributes,
+            extensions: _,
+        } = opts;
+
+        if tags != Default::default() || attributes != Default::default() {
+            return Err(Error::NotSupported {
+                source: "`create_multipart_opts` with non-default options is not supported by MicrosoftAzure".into(),
+            });
+        }
+
+        self.create_multipart(path).await
+    }
+
     async fn put_part(
         &self,
         path: &Path,
@@ -336,7 +356,28 @@ mod tests {
     use crate::ObjectStoreExt;
     use crate::integration::*;
     use crate::tests::*;
+    use crate::{Attribute, Attributes};
     use bytes::Bytes;
+
+    #[tokio::test]
+    async fn azure_create_multipart_opts_rejects_attributes() {
+        let integration = MicrosoftAzureBuilder::new()
+            .with_container_name("test")
+            .with_use_emulator(true)
+            .build()
+            .unwrap();
+        let opts = PutMultipartOptions {
+            attributes: Attributes::from_iter([(Attribute::Metadata("key".into()), "value")]),
+            ..Default::default()
+        };
+
+        let err = integration
+            .create_multipart_opts(&Path::from("test"), opts)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::NotSupported { .. }));
+    }
 
     #[tokio::test]
     async fn azure_blob_test() {

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -233,6 +233,14 @@ impl MultipartStore for GoogleCloudStorage {
             .await
     }
 
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        self.client.multipart_initiate(path, opts).await
+    }
+
     async fn put_part(
         &self,
         path: &Path,
@@ -326,6 +334,7 @@ mod test {
             // https://github.com/fsouza/fake-gcs-server/issues/852
             stream_get(&integration).await;
             multipart(&integration, &integration).await;
+            multipart_with_opts(&integration, &integration).await;
             multipart_put_part_out_of_order(&integration, &integration).await;
             multipart_race_condition(&integration, true).await;
             multipart_out_of_order(&integration).await;

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1083,7 +1083,10 @@ pub async fn multipart_with_opts(storage: &dyn ObjectStore, multipart: &dyn Mult
 
     let result = storage.get(&path).await.unwrap();
     assert_eq!(result.meta.size, chunk_size as u64 * 2);
-    assert_eq!(result.attributes, attributes);
+    // Some providers add default attributes, e.g. S3 may report a default Content-Type.
+    for (attribute, value) in &attributes {
+        assert_eq!(result.attributes.get(attribute), Some(value));
+    }
 }
 
 /// Tests that [`MultipartStore::put_part`] may be invoked with non-sequential part indices.

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -29,7 +29,8 @@ use crate::multipart::MultipartStore;
 use crate::path::Path;
 use crate::{
     Attribute, Attributes, DynObjectStore, Error, GetOptions, GetRange, MultipartUpload,
-    ObjectStore, ObjectStoreExt, PutMode, PutPayload, UpdateVersion, WriteMultipart,
+    ObjectStore, ObjectStoreExt, PutMode, PutMultipartOptions, PutPayload, UpdateVersion,
+    WriteMultipart,
 };
 use bytes::Bytes;
 use futures_util::stream::FuturesUnordered;
@@ -1051,6 +1052,38 @@ pub async fn multipart(storage: &dyn ObjectStore, multipart: &dyn MultipartStore
 
     let meta = storage.head(&path).await.unwrap();
     assert_eq!(meta.size, 0);
+}
+
+/// Tests [`MultipartStore::create_multipart_opts`]
+pub async fn multipart_with_opts(storage: &dyn ObjectStore, multipart: &dyn MultipartStore) {
+    let path = Path::from("test_multipart_with_opts");
+    let chunk_size = 5 * 1024 * 1024;
+    let chunks = get_chunks(chunk_size, 2);
+    let attributes =
+        Attributes::from_iter([(Attribute::Metadata("test_key".into()), "test_value")]);
+    let opts = PutMultipartOptions {
+        attributes: attributes.clone(),
+        ..Default::default()
+    };
+
+    let id = multipart.create_multipart_opts(&path, opts).await.unwrap();
+
+    let parts: Vec<_> = futures_util::stream::iter(chunks)
+        .enumerate()
+        .map(|(idx, b)| multipart.put_part(&path, &id, idx, b.into()))
+        .buffered(2)
+        .try_collect()
+        .await
+        .unwrap();
+
+    multipart
+        .complete_multipart(&path, &id, parts)
+        .await
+        .unwrap();
+
+    let result = storage.get(&path).await.unwrap();
+    assert_eq!(result.meta.size, chunk_size as u64 * 2);
+    assert_eq!(result.attributes, attributes);
 }
 
 /// Tests that [`MultipartStore::put_part`] may be invoked with non-sequential part indices.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -116,6 +116,7 @@ struct Storage {
 
 #[derive(Debug, Default, Clone)]
 struct PartStorage {
+    attributes: Attributes,
     parts: Vec<Option<Bytes>>,
 }
 
@@ -417,10 +418,25 @@ impl ObjectStore for InMemory {
 #[async_trait]
 impl MultipartStore for InMemory {
     async fn create_multipart(&self, _path: &Path) -> Result<MultipartId> {
+        self.create_multipart_opts(_path, PutMultipartOptions::default())
+            .await
+    }
+
+    async fn create_multipart_opts(
+        &self,
+        _path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
         let mut storage = self.storage.write();
         let etag = storage.next_etag;
         storage.next_etag += 1;
-        storage.uploads.insert(etag, Default::default());
+        storage.uploads.insert(
+            etag,
+            PartStorage {
+                attributes: opts.attributes,
+                parts: Default::default(),
+            },
+        );
         Ok(etag.to_string())
     }
 
@@ -459,7 +475,7 @@ impl MultipartStore for InMemory {
         for x in &upload.parts {
             buf.extend_from_slice(x.as_ref().unwrap())
         }
-        let etag = storage.insert(path, buf.into(), Default::default());
+        let etag = storage.insert(path, buf.into(), upload.attributes);
         Ok(PutResult {
             e_tag: Some(etag.to_string()),
             version: None,
@@ -557,6 +573,7 @@ mod tests {
         stream_get(&integration).await;
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
+        multipart_with_opts(&integration, &integration).await;
         put_get_attributes(&integration).await;
         multipart_put_part_out_of_order(&integration, &integration).await;
     }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -24,7 +24,7 @@
 use async_trait::async_trait;
 
 use crate::path::Path;
-use crate::{MultipartId, PutPayload, PutResult, Result};
+use crate::{Error, MultipartId, PutMultipartOptions, PutPayload, PutResult, Result};
 
 /// Represents a part of a file that has been successfully uploaded in a multipart upload process.
 #[derive(Debug, Clone)]
@@ -45,6 +45,30 @@ pub struct PartId {
 pub trait MultipartStore: Send + Sync + 'static {
     /// Creates a new multipart upload, returning the [`MultipartId`]
     async fn create_multipart(&self, path: &Path) -> Result<MultipartId>;
+
+    /// Creates a new multipart upload with the given options, returning the [`MultipartId`]
+    ///
+    /// This allows callers using the low-level multipart API to provide object attributes,
+    /// tags, or implementation-specific extensions when initiating the upload.
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        let PutMultipartOptions {
+            tags,
+            attributes,
+            extensions: _,
+        } = opts;
+
+        if tags != Default::default() || attributes != Default::default() {
+            return Err(Error::NotSupported {
+                source: "create_multipart_opts with non-default options".into(),
+            });
+        }
+
+        self.create_multipart(path).await
+    }
 
     /// Uploads a new part with index `part_idx`
     ///
@@ -81,4 +105,59 @@ pub trait MultipartStore: Send + Sync + 'static {
 
     /// Aborts a multipart upload
     async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Extensions;
+
+    struct TestMultipartStore;
+
+    #[async_trait]
+    impl MultipartStore for TestMultipartStore {
+        async fn create_multipart(&self, _path: &Path) -> Result<MultipartId> {
+            Ok("test".into())
+        }
+
+        async fn put_part(
+            &self,
+            _path: &Path,
+            _id: &MultipartId,
+            _part_idx: usize,
+            _data: PutPayload,
+        ) -> Result<PartId> {
+            unreachable!()
+        }
+
+        async fn complete_multipart(
+            &self,
+            _path: &Path,
+            _id: &MultipartId,
+            _parts: Vec<PartId>,
+        ) -> Result<PutResult> {
+            unreachable!()
+        }
+
+        async fn abort_multipart(&self, _path: &Path, _id: &MultipartId) -> Result<()> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn default_create_multipart_opts_ignores_extensions() {
+        let mut extensions = Extensions::new();
+        extensions.insert("extension");
+        let opts = PutMultipartOptions {
+            extensions,
+            ..Default::default()
+        };
+
+        let id = TestMultipartStore
+            .create_multipart_opts(&Path::from("test"), opts)
+            .await
+            .unwrap();
+
+        assert_eq!(id, "test");
+    }
 }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -61,7 +61,7 @@ pub trait MultipartStore: Send + Sync + 'static {
             extensions: _,
         } = opts;
 
-        if tags != Default::default() || attributes != Default::default() {
+        if !tags.is_empty() || !attributes.is_empty() {
             return Err(Error::NotSupported {
                 source: "create_multipart_opts with non-default options".into(),
             });

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -209,6 +209,15 @@ impl<T: MultipartStore> MultipartStore for PrefixStore<T> {
         self.inner.create_multipart(&full_path).await
     }
 
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        let full_path = self.full_path(path);
+        self.inner.create_multipart_opts(&full_path, opts).await
+    }
+
     async fn put_part(
         &self,
         path: &Path,
@@ -391,6 +400,7 @@ mod tests {
         let store = PrefixStore::new(InMemory::new(), "prefix");
 
         multipart(&store, &store).await;
+        multipart_with_opts(&store, &store).await;
         multipart_put_part_out_of_order(&store, &store).await;
         multipart_out_of_order(&store).await;
         multipart_race_condition(&store, true).await;

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -41,6 +41,11 @@ impl TagSet {
     pub fn encoded(&self) -> &str {
         &self.0
     }
+
+    /// Return whether this [`TagSet`] contains any tags
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -310,6 +310,14 @@ impl<T: MultipartStore> MultipartStore for ThrottledStore<T> {
         self.inner.create_multipart(path).await
     }
 
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<MultipartId> {
+        self.inner.create_multipart_opts(path, opts).await
+    }
+
     async fn put_part(
         &self,
         path: &Path,
@@ -400,6 +408,7 @@ mod tests {
         copy_if_not_exists(&store).await;
         stream_get(&store).await;
         multipart(&store, &store).await;
+        multipart_with_opts(&store, &store).await;
         multipart_put_part_out_of_order(&store, &store).await;
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Adds `PutMultipartOptions` support to the low-level `MultipartStore` create flow via a new `create_multipart_opts` method.

This is implemented for AWS, GCP, in-memory, and wrapper stores. Azure returns `NotSupported` for non-default tags/attributes because Azure applies these options when finalizing block uploads, not when creating them. Supporting this in the low-level API would require local upload state, which could leak if uploads are never completed or aborted.

Closes #745

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
See issue.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Adds `MultipartStore::create_multipart_opts`
* For AWS/GCP, passes options through to the backend client
* For `PrefixStore`/`ThrottledStore`, delegates options to the wrapped multipart store
* For in-memory, stores attributes in `PartStorage` until completion
* For Azure, returns `NotSupported` for non-default tags/attributes

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. `MultipartStore` has a new default method, `create_multipart_opts`, so existing implementations remain source-compatible.

<!---
If there are any breaking changes to public APIs, please call them out.
-->
There are no breaking changes to the public API; the new method has a default implementation.
