### PR TITLE
Fix flaky local close-file tests

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -143,23 +143,34 @@ impl From<Error> for super::Error {
 fn close_file(file: File) -> std::result::Result<(), io::Error> {
     #[cfg(target_family = "unix")]
     {
-        nix::unistd::close(file).map_err(|e| e.into())
+        use std::os::fd::IntoRawFd;
+
+        close_fd(file.into_raw_fd())
     }
     #[cfg(target_family = "windows")]
     {
         use std::os::windows::io::IntoRawHandle;
 
-        let handle = file.into_raw_handle();
-        // SAFETY: `handle` is a valid, owned handle obtained from `into_raw_handle()`.
-        match unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) } {
-            0 => Err(io::Error::last_os_error()),
-            _ => Ok(()),
-        }
+        close_handle(file.into_raw_handle())
     }
     #[cfg(not(any(target_family = "unix", target_family = "windows")))]
     {
         drop(file);
         Ok(())
+    }
+}
+
+#[cfg(target_family = "unix")]
+fn close_fd(fd: std::os::fd::RawFd) -> std::result::Result<(), io::Error> {
+    nix::unistd::close(fd).map_err(|e| e.into())
+}
+
+#[cfg(target_family = "windows")]
+fn close_handle(handle: std::os::windows::io::RawHandle) -> std::result::Result<(), io::Error> {
+    // SAFETY: `handle` must be an owned handle, except when testing invalid handle errors.
+    match unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) } {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok(()),
     }
 }
 
@@ -1893,37 +1904,14 @@ mod tests {
     #[test]
     #[cfg(target_family = "unix")]
     fn test_close_file_detects_error_unix() {
-        use std::os::fd::FromRawFd;
-        use std::os::unix::io::AsRawFd;
-
-        let file = tempfile::tempfile().unwrap();
-
-        // Close and reclaim a File from the now-invalid fd
-        let file = {
-            let fd = file.as_raw_fd();
-            super::close_file(file).unwrap();
-            unsafe { std::fs::File::from_raw_fd(fd) }
-        };
-
-        let err = super::close_file(file).unwrap_err();
+        let err = super::close_fd(-1).unwrap_err();
         assert_eq!(err.raw_os_error(), Some(nix::libc::EBADF), "got: {err:?}");
     }
 
     #[test]
     #[cfg(target_family = "windows")]
     fn test_close_file_detects_error_windows() {
-        use std::os::windows::io::{AsRawHandle, FromRawHandle};
-
-        let file = tempfile::tempfile().unwrap();
-
-        // Close and reclaim a File from the now-invalid handle
-        let file = {
-            let handle = file.as_raw_handle();
-            super::close_file(file).unwrap();
-            unsafe { std::fs::File::from_raw_handle(handle) }
-        };
-
-        let err = super::close_file(file).unwrap_err();
+        let err = super::close_handle(std::ptr::null_mut()).unwrap_err();
         assert_eq!(
             err.raw_os_error(),
             Some(windows_sys::Win32::Foundation::ERROR_INVALID_HANDLE as i32),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The close-file error tests tried to force an error by closing a temp file, rebuilding a `File` from the now-invalid fd/handle, and closing it again. In parallel test runs, that fd/handle value can be reused by another test, causing the close test to unexpectedly succeed or close another test's resource.

This makes CI flaky and has affected two PRs recently:
- apache/arrow-rs-object-store#742: https://github.com/apache/arrow-rs-object-store/actions/runs/27587416868/job/81712651684?pr=742
- apache/arrow-rs-object-store#710: https://github.com/apache/arrow-rs-object-store/actions/runs/25238554718/job/74009722459?pr=710

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This adds small Unix and Windows helpers for closing raw fd/handle values, and keeps `close_file(File)` delegating to those helpers.

The close-file error tests now assert the expected invalid fd/handle errors directly, instead of reconstructing a `File` from a closed resource.

# Are there any user-facing changes?
No. This only changes internal test coverage for local filesystem close-error handling.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
