### PR TITLE
fix(local): fsync create-mode rename source delete

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -513,9 +513,8 @@ impl ObjectStore for LocalFileSystem {
                 let config = Arc::clone(&config);
                 maybe_spawn_blocking(move || {
                     let location = location?;
-                    // Do not apply `with_fsync` to standalone deletes.
-                    // Use `fsync=true` only when removing the source after a synced copy in
-                    // `rename_if_not_exists`.
+                    // `with_fsync` does not apply to standalone deletes; only create-mode rename
+                    // fsyncs its internal source removal as part of the durable copy-and-delete.
                     Self::delete_location(config, automatic_cleanup, &location, false)?;
                     Ok(location)
                 })

--- a/src/local.rs
+++ b/src/local.rs
@@ -44,7 +44,7 @@ use crate::{
     path::{Path, absolute_path_to_url},
     util::InvalidGetRange,
 };
-use crate::{CopyMode, CopyOptions, ObjectStoreExt, RenameOptions, RenameTargetMode};
+use crate::{CopyMode, CopyOptions, RenameOptions, RenameTargetMode};
 
 /// A specialized `Error` for filesystem object store-related errors
 #[derive(Debug, thiserror::Error)]
@@ -513,7 +513,10 @@ impl ObjectStore for LocalFileSystem {
                 let config = Arc::clone(&config);
                 maybe_spawn_blocking(move || {
                     let location = location?;
-                    Self::delete_location(config, automatic_cleanup, &location)?;
+                    // Do not apply `with_fsync` to standalone deletes.
+                    // Use `fsync=true` only when removing the source after a synced copy in
+                    // `rename_if_not_exists`.
+                    Self::delete_location(config, automatic_cleanup, &location, false)?;
                     Ok(location)
                 })
             })
@@ -716,7 +719,14 @@ impl ObjectStore for LocalFileSystem {
                     },
                 )
                 .await?;
-                self.delete(from).await?;
+                let config = Arc::clone(&self.config);
+                let automatic_cleanup = self.automatic_cleanup;
+                let fsync = self.fsync;
+                let from = from.clone();
+                maybe_spawn_blocking(move || {
+                    Self::delete_location(config, automatic_cleanup, &from, fsync)
+                })
+                .await?;
                 Ok(())
             }
         }
@@ -728,6 +738,7 @@ impl LocalFileSystem {
         config: Arc<Config>,
         automatic_cleanup: bool,
         location: &Path,
+        fsync: bool,
     ) -> Result<()> {
         let path = config.path_to_filesystem(location)?;
         if let Err(e) = std::fs::remove_file(&path) {
@@ -735,7 +746,18 @@ impl LocalFileSystem {
                 ErrorKind::NotFound => Error::NotFound { path, source: e }.into(),
                 _ => Error::UnableToDeleteFile { path, source: e }.into(),
             })
-        } else if automatic_cleanup {
+        } else {
+            if fsync {
+                fsync_parent_dir(&path).map_err(|source| Error::UnableToSyncFile {
+                    source,
+                    path: path.clone(),
+                })?;
+            }
+
+            if !automatic_cleanup {
+                return Ok(());
+            }
+
             let root = &config.root;
             let root = root
                 .to_file_path()
@@ -752,8 +774,6 @@ impl LocalFileSystem {
                 }
             }
 
-            Ok(())
-        } else {
             Ok(())
         }
     }
@@ -1471,6 +1491,9 @@ mod tests {
     use tempfile::TempDir;
 
     #[cfg(target_family = "unix")]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(target_family = "unix")]
     use tempfile::NamedTempFile;
 
     use crate::{ObjectStoreExt, integration::*};
@@ -1557,6 +1580,43 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(read, data);
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn fsync_rename_if_not_exists_propagates_source_delete_sync_error() {
+        let root = TempDir::new().unwrap();
+        let integration = LocalFileSystem::new_with_prefix(root.path())
+            .unwrap()
+            .with_fsync(true);
+
+        let source = Path::from("source_dir/source_file");
+        let dest = Path::from("dest_dir/dest_file");
+        integration.put(&source, "data".into()).await.unwrap();
+
+        let source_dir = root.path().join("source_dir");
+        let original_permissions = fs::metadata(&source_dir).unwrap().permissions();
+        // Allow unlinking the file from the directory, but prevent opening the
+        // directory for fsync. Without the source-parent fsync, rename succeeds;
+        // with it, the sync error is propagated after the source is deleted.
+        fs::set_permissions(&source_dir, fs::Permissions::from_mode(0o300)).unwrap();
+
+        let result = integration.rename_if_not_exists(&source, &dest).await;
+        fs::set_permissions(&source_dir, original_permissions).unwrap();
+
+        match result {
+            Err(crate::Error::Generic { source, .. }) => {
+                assert!(source.to_string().contains("Unable to sync data to disk"));
+            }
+            _ => panic!("expected source parent fsync to fail"),
+        }
+
+        let read = integration.get(&dest).await.unwrap().bytes().await.unwrap();
+        assert_eq!(read, Bytes::from("data"));
+        assert!(matches!(
+            integration.get(&source).await.unwrap_err(),
+            crate::Error::NotFound { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
- Follow-up to #643.
- part of https://github.com/apache/arrow-rs-object-store/issues/661

`rename_if_not_exists` uses `RenameTargetMode::Create`, which is implemented as copy-then-delete. The copy side now goes through the fsync-aware path, but the source delete also needs to sync the source parent directory when `with_fsync(true)` is enabled so the source-name removal is durable before `rename_opts` returns.

This keeps normal `delete_stream` behavior unchanged and only passes `self.fsync` for the internal delete that is part of create-mode rename.

Validation:
- cargo test -p object_store fsync_rename_if_not_exists_propagates_source_delete_sync_error
- cargo test -p object_store local::tests::