### PR TITLE
Update release schedule on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ Planned Release Schedule
 | Approximate Date | Version  | Notes                          | Ticket                                                             |
 |------------------|----------|--------------------------------|:-------------------------------------------------------------------|
 | May 2026         | `0.14.0` | Major, breaking API changes    | [#673](https://github.com/apache/arrow-rs-object-store/issues/673) |
-| Jul 2026         | `0.14.1` | Minor, NO breaking API changes | [#761](https://github.com/apache/arrow-rs-object-store/issues/761) |
+| Aug 2026         | `0.14.1` | Minor, NO breaking API changes | [#761](https://github.com/apache/arrow-rs-object-store/issues/761) |
 | Sep 2026         | `0.15.0` | Major, breaking API changes    | [#762](https://github.com/apache/arrow-rs-object-store/issues/762) |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,6 @@ Planned Release Schedule
 
 | Approximate Date | Version  | Notes                          | Ticket                                                             |
 |------------------|----------|--------------------------------|:-------------------------------------------------------------------|
-| Feb 2026         | `0.13.2` | Minor, NO breaking API changes | [#393](https://github.com/apache/arrow-rs-object-store/issues/393) |
-| May 2026         | `0.13.3` | Minor, NO breaking API changes | [#672](https://github.com/apache/arrow-rs-object-store/issues/672) |
 | May 2026         | `0.14.0` | Major, breaking API changes    | [#673](https://github.com/apache/arrow-rs-object-store/issues/673) |
+| Jul 2026         | `0.14.1` | Minor, NO breaking API changes | [#761](https://github.com/apache/arrow-rs-object-store/issues/761) |
+| Sep 2026         | `0.15.0` | Major, breaking API changes    | [#762](https://github.com/apache/arrow-rs-object-store/issues/762) |


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs-object-store/issues/392

# Rationale for this change

While preparing the upcoming releases, update the planned release schedule in the README to reflect the newly filed tickets.

# What changes are included in this PR?

Add ticket links and target dates for the planned `0.14.1` (#761) and `0.15.0` (#762) releases, and drop the already-released rows.

Note I am flexible on the proposed dates and if people need / desire faster releases we can improve them over time.

# Are there any user-facing changes?

Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)