### PR TITLE
Clarify aws-lc-rs feature docs and fix CI comment URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         run: cargo clippy --no-default-features --features http-base -- -D warnings
       # Testing matrix of HTTP and crypto providers
       #
-      # Improvements tracked in  https://githubcom/apache/arrow-rs-object-store/issues/759
+      # Improvements tracked in  https://github.com/apache/arrow-rs-object-store/issues/759
       #
       # Notes:
       # Direct `reqwest` needs a TLS backend. Use `rustls-no-provider` so TLS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@
 //! transport (e.g. `aws-base` + `aws-lc-rs` with a custom [`HttpConnector`]),
 //! you must also select an [`aws-lc-rs`] backend, as `object_store` does not
 //! pick one for you.
-//! For example enable `aws-lc-rs/aws-lc-sys` (or `fips` / `non-fips`). 
+//! For example enable `aws-lc-rs/aws-lc-sys` (or `fips` / `non-fips`).
 //!
 //! If both `ring` and `aws-lc-rs` are enabled, `aws-lc-rs` is used by default.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,12 @@
 //! If you wish to use [`ring`] (e.g. to support WASM targets), use the
 //! `*-base` feature flags, e.g. `aws-base`, and then enable the `ring` feature.
 //!
+//! When enabling the `aws-lc-rs` feature without the built-in `reqwest`
+//! transport (e.g. `aws-base` + `aws-lc-rs` with a custom [`HttpConnector`]),
+//! you must also select an [`aws-lc-rs`] backend, as `object_store` does not
+//! pick one for you. For example enable `aws-lc-rs/aws-lc-sys` (or `fips` /
+//! `non-fips`). 
+//!
 //! If both `ring` and `aws-lc-rs` are enabled, `aws-lc-rs` is used by default.
 //!
 //! You can also implement a custom [`client::CryptoProvider`] to use your own cryptographic library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,8 +610,8 @@
 //! When enabling the `aws-lc-rs` feature without the built-in `reqwest`
 //! transport (e.g. `aws-base` + `aws-lc-rs` with a custom [`HttpConnector`]),
 //! you must also select an [`aws-lc-rs`] backend, as `object_store` does not
-//! pick one for you. For example enable `aws-lc-rs/aws-lc-sys` (or `fips` /
-//! `non-fips`). 
+//! pick one for you.
+//! For example enable `aws-lc-rs/aws-lc-sys` (or `fips` / `non-fips`). 
 //!
 //! If both `ring` and `aws-lc-rs` are enabled, `aws-lc-rs` is used by default.
 //!


### PR DESCRIPTION
# Which issue does this PR close?

Follow-on documentation polish from 
- #707. 

# Rationale for this change

While reviewing #707 (Pluggable Crypto / reqwest 0.13) after merge, claude found 2 doc issues:

1. `object_store`'s `aws-lc-rs` feature deliberately does **not** select an `aws-lc-rs` backend (`aws-lc-sys` / `fips` / `non-fips`), so that downstream crates retain control over that choice. As a result, enabling `aws-lc-rs` together with a `*-base` feature but *without* the built-in `reqwest` transport fails to compile until the user selects a backend. This was non-obvious and not documented.
2. A comment in `ci.yml` had a broken issue link (`https://githubcom/...`, missing the `.`).

# What changes are included in this PR?
- Fix above

# Are there any user-facing changes?

Documentation only — clarifies an existing feature-flag requirement. No API or behavior changes, and nothing breaking.