### PR TITLE
fix: quote ETags per RFC 9110 in InMemory and LocalFileSystem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2492,7 +2492,7 @@ mod tests {
             location: Path::from("test"),
             last_modified: Utc.timestamp_nanos(100),
             size: 100,
-            e_tag: Some("123".to_string()),
+            e_tag: Some("\"123\"".to_string()),
             version: None,
         };
 
@@ -2521,16 +2521,16 @@ mod tests {
 
         options = GetOptions::default();
 
-        options.if_match = Some("123".to_string());
+        options.if_match = Some("\"123\"".to_string());
         options.check_preconditions(&meta).unwrap();
 
-        options.if_match = Some("123,354".to_string());
+        options.if_match = Some("\"123\",\"354\"".to_string());
         options.check_preconditions(&meta).unwrap();
 
-        options.if_match = Some("354, 123,".to_string());
+        options.if_match = Some("\"354\", \"123\"".to_string());
         options.check_preconditions(&meta).unwrap();
 
-        options.if_match = Some("354".to_string());
+        options.if_match = Some("\"354\"".to_string());
         options.check_preconditions(&meta).unwrap_err();
 
         options.if_match = Some("*".to_string());
@@ -2542,16 +2542,16 @@ mod tests {
 
         options = GetOptions::default();
 
-        options.if_none_match = Some("123".to_string());
+        options.if_none_match = Some("\"123\"".to_string());
         options.check_preconditions(&meta).unwrap_err();
 
         options.if_none_match = Some("*".to_string());
         options.check_preconditions(&meta).unwrap_err();
 
-        options.if_none_match = Some("1232".to_string());
+        options.if_none_match = Some("\"1232\"".to_string());
         options.check_preconditions(&meta).unwrap();
 
-        options.if_none_match = Some("23, 123".to_string());
+        options.if_none_match = Some("\"23\", \"123\"".to_string());
         options.check_preconditions(&meta).unwrap_err();
 
         // If-None-Match takes precedence

--- a/src/local.rs
+++ b/src/local.rs
@@ -1418,7 +1418,7 @@ fn get_etag(metadata: &Metadata) -> String {
     // Use an ETag scheme based on that used by many popular HTTP servers
     // <https://httpd.apache.org/docs/2.2/mod/core.html#fileetag>
     // <https://stackoverflow.com/questions/47512043/how-etags-are-generated-and-configured>
-    format!("{inode:x}-{mtime:x}-{size:x}")
+    format!("\"{inode:x}-{mtime:x}-{size:x}\"")
 }
 
 fn convert_metadata(metadata: Metadata, location: Path) -> ObjectMeta {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -157,7 +157,7 @@ impl Storage {
                 source: format!("Object at location {location} not found").into(),
             }),
             Some(e) => {
-                let existing = e.e_tag.to_string();
+                let existing = format!("\"{}\"", e.e_tag);
                 let expected = v.e_tag.ok_or(Error::MissingETag)?;
                 if existing == expected {
                     *e = entry;
@@ -217,7 +217,7 @@ impl ObjectStore for InMemory {
         storage.next_etag += 1;
 
         Ok(PutResult {
-            e_tag: Some(etag.to_string()),
+            e_tag: Some(format!("\"{}\"", etag)),
             version: None,
             extensions: Default::default(),
         })
@@ -238,7 +238,7 @@ impl ObjectStore for InMemory {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let entry = self.entry(location)?;
-        let e_tag = entry.e_tag.to_string();
+        let e_tag = format!("\"{}\"", entry.e_tag);
 
         let meta = ObjectMeta {
             location: location.clone(),
@@ -331,7 +331,7 @@ impl ObjectStore for InMemory {
                     location: key.clone(),
                     last_modified: value.last_modified,
                     size: value.data.len() as u64,
-                    e_tag: Some(value.e_tag.to_string()),
+                    e_tag: Some(format!("\"{}\"", value.e_tag)),
                     version: None,
                 })
             })
@@ -376,7 +376,7 @@ impl ObjectStore for InMemory {
                     location: k.clone(),
                     last_modified: v.last_modified,
                     size: v.data.len() as u64,
-                    e_tag: Some(v.e_tag.to_string()),
+                    e_tag: Some(format!("\"{}\"", v.e_tag)),
                     version: None,
                 };
                 objects.push(object);
@@ -480,7 +480,7 @@ impl MultipartStore for InMemory {
         }
         let etag = storage.insert(path, buf.into(), upload.attributes);
         Ok(PutResult {
-            e_tag: Some(etag.to_string()),
+            e_tag: Some(format!("\"{}\"", etag)),
             version: None,
             extensions: Default::default(),
         })
@@ -547,7 +547,7 @@ impl MultipartUpload for InMemoryUpload {
         );
 
         Ok(PutResult {
-            e_tag: Some(etag.to_string()),
+            e_tag: Some(format!("\"{}\"", etag)),
             version: None,
             extensions: Default::default(),
         })


### PR DESCRIPTION
# Which issue does this PR close?

Closes #769

# Rationale for this change
 
Cloud-backed stores (AWS, Azure, GCP) return ETags as quoted-strings (e.g. `"abc123"`) and expect `If-Match`/`If-None-Match` values in that same form, as required by [RFC 9110 §8.8.3](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3) and [§13 (Preconditions)](https://datatracker.ietf.org/doc/html/rfc9110#name-preconditions).

`InMemory` and `LocalFileSystem`, by contrast, were producing bare tokens, making them inconsistent with the cloud backends and harder to use as drop-in replacements.

RFC 9110 is already the reference linked from `ObjectMeta::e_tag`, `GetOptions::if_match`, and `GetOptions::if_none_match` in this crate's [docs](https://docs.rs/object_store/latest/object_store/struct.GetOptions.html), where examples already use the quoted form.

# What changes are included in this PR?

- `src/local.rs`: wrap `get_etag` output in double quotes
- `src/memory.rs`: wrap all ETag values produced by `InMemory` / `InMemoryUpload` in double quotes
- `src/lib.rs`: update precondition tests to use properly quoted ETags

# Are there any user-facing changes?

`InMemory` and `LocalFileSystem` now return ETags in the form `"<value>"` instead of `<value>`. Other backends are unaffected.

Code that treats ETags as opaque strings and passes them back via `if_match` or `if_none_match` as-is will not be impacted.

However, code that expected the implementation-specific unquoted ETag format from one of these two backends might be impacted.