### PR TITLE
fix: accept GCS gzip responses without Content-Length

### DIFF
--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -922,6 +922,7 @@ impl GetClient for S3Client {
     const HEADER_CONFIG: HeaderConfig = HeaderConfig {
         etag_required: false,
         last_modified_required: false,
+        stored_size_header: None,
         version_header: Some(VERSION_HEADER),
         user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };

--- a/src/azure/client.rs
+++ b/src/azure/client.rs
@@ -1075,6 +1075,7 @@ impl GetClient for AzureClient {
     const HEADER_CONFIG: HeaderConfig = HeaderConfig {
         etag_required: true,
         last_modified_required: true,
+        stored_size_header: None,
         version_header: Some(VERSION_HEADER),
         user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };

--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -445,6 +445,7 @@ mod tests {
     const CFG: HeaderConfig = HeaderConfig {
         etag_required: false,
         last_modified_required: false,
+        stored_size_header: None,
         version_header: None,
         user_defined_metadata_prefix: Some("x-test-meta-"),
     };
@@ -505,6 +506,54 @@ mod tests {
         let resp = make_response(6, StatusCode::PARTIAL_CONTENT, Some("bytes 2-3/6"), None);
         let err = get_range_meta(CFG, &path, Some(&GetRange::Suffix(4)), &resp).unwrap_err();
         assert_eq!(err.to_string(), "Requested 2..6, got 2..4");
+    }
+
+    #[test]
+    fn test_get_missing_content_length() {
+        // Mirrors the GCS config: size falls back to x-goog-stored-content-length.
+        const RELAXED: HeaderConfig = HeaderConfig {
+            stored_size_header: Some("x-goog-stored-content-length"),
+            ..CFG
+        };
+        let path = Path::from("test");
+
+        let resp = |headers: &[(&str, &str)]| {
+            let mut builder = http::Response::builder().status(StatusCode::OK);
+            for (k, v) in headers {
+                builder = builder.header(*k, *v);
+            }
+            builder.body(()).unwrap().into_parts().0
+        };
+
+        // No Content-Length, stored-size header present -> best-effort size from fallback.
+        let r = resp(&[("x-goog-stored-content-length", "355")]);
+        let (range, meta) = get_range_meta(RELAXED, &path, None, &r).unwrap();
+        assert_eq!(meta.size, 355);
+        assert_eq!(range, 0..355);
+
+        // No Content-Length and the stored-size header also absent -> still an error.
+        let r = resp(&[]);
+        let err = get_range_meta(RELAXED, &path, None, &r).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Content-Length Header missing from response"
+        );
+
+        // A present Content-Length always wins over the fallback.
+        let r = resp(&[
+            ("content-length", "10"),
+            ("x-goog-stored-content-length", "355"),
+        ]);
+        let (_, meta) = get_range_meta(RELAXED, &path, None, &r).unwrap();
+        assert_eq!(meta.size, 10);
+
+        // With the strict default (S3/Azure), a missing Content-Length is still fatal.
+        let r = resp(&[]);
+        let err = get_range_meta(CFG, &path, None, &r).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Content-Length Header missing from response"
+        );
     }
 
     #[test]

--- a/src/client/header.rs
+++ b/src/client/header.rs
@@ -36,6 +36,14 @@ pub(crate) struct HeaderConfig {
     /// Defaults to `true`
     pub last_modified_required: bool,
 
+    /// Header to read the object size from when `Content-Length` is absent.
+    ///
+    /// GCS omits `Content-Length` on chunked `Content-Encoding: gzip` responses — large
+    /// bodies, or decompressive transcoding — but always sends `x-goog-stored-content-length`.
+    /// Stores that always send a `Content-Length` (S3, Azure) leave this `None`, so a missing
+    /// `Content-Length` stays an error for them.
+    pub stored_size_header: Option<&'static str>,
+
     /// The version header name if any
     pub version_header: Option<&'static str>,
 
@@ -139,8 +147,12 @@ pub(crate) fn header_meta(
         Err(e) => return Err(e),
     };
 
+    // Prefer `Content-Length`, falling back to a store-provided size header: GCS omits
+    // `Content-Length` on chunked gzip responses (large bodies, or transcoding) but always
+    // sends `x-goog-stored-content-length`. Stores without such a header still require it.
     let content_length = headers
         .get(CONTENT_LENGTH)
+        .or_else(|| cfg.stored_size_header.and_then(|h| headers.get(h)))
         .ok_or(Error::MissingContentLength)?;
 
     let content_length = content_length

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -52,6 +52,7 @@ const VERSION_HEADER: &str = "x-goog-generation";
 const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-goog-meta-";
 const STORAGE_CLASS: &str = "x-goog-storage-class";
+const STORED_CONTENT_LENGTH_HEADER: &str = "x-goog-stored-content-length";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
 
@@ -617,9 +618,12 @@ impl GoogleCloudStorageClient {
 #[async_trait]
 impl GetClient for GoogleCloudStorageClient {
     const STORE: &'static str = STORE;
+    // GCS omits Content-Length on chunked gzip responses (large bodies, or decompressive
+    // transcoding); the size is recovered from x-goog-stored-content-length instead.
     const HEADER_CONFIG: HeaderConfig = HeaderConfig {
         etag_required: true,
         last_modified_required: true,
+        stored_size_header: Some(STORED_CONTENT_LENGTH_HEADER),
         version_header: Some(VERSION_HEADER),
         user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -359,6 +359,7 @@ impl GetClient for Client {
     const HEADER_CONFIG: HeaderConfig = HeaderConfig {
         etag_required: false,
         last_modified_required: false,
+        stored_size_header: None,
         version_header: None,
         user_defined_metadata_prefix: None,
     };


### PR DESCRIPTION
# Which issue does this PR close?

Part of #774 (does not fully close it — see below).

# Rationale for this change

GCS serves large objects stored with `Content-Encoding: gzip` using chunked transfer with no `Content-Length` (and decompressive transcoding when the client does not accept gzip encoding). `ObjectStore::get`/`head` on GCS required
`Content-Length` unconditionally and failed with `Generic { store: "GCS", source: Header { source: MissingContentLength } }`, even though a chunked, self-delimiting body is a valid response (RFC 9112 §6.2 forbids `Content-Length` alongside `Transfer-Encoding: chunked`).

# What changes are included in this PR?

`HeaderConfig` gains `stored_size_header: Option<&'static str>`. When `Content-Length` is absent, `header_meta` reads the object size from this header. GCS sets it to `x-goog-stored-content-length` (always present); S3, Azure and the
HTTP store leave it `None`, so a missing `Content-Length` stays a hard error for them.

# Are there any user-facing changes?

`get()`/`head()` now succeed on chunked gzip GCS objects. On a server-decompressed (transcoded) read, `ObjectMeta.size` is the *stored* (compressed) size, since the decompressed length is not known without reading the body; on a passthrough read (`Accept-Encoding: gzip`) it is exact.

**Not fully resolved:** some transcoded GCS responses (default reads without `Accept-Encoding: gzip`) also omit the ETag entirely and still fail with `MissingEtag`. Left for a follow-up.

-------------------

**:robot: AI disclaimer**:
All the code written by Claude. I made the changes as targeted and minimal as possible, for now only focusing on the chunked encoding, because that's my major blocker. Decompressive transcoding feels kind of niche. And the ETag handling involves some more thought and knowledge about this repo. E.g. I think the different Cloud vendors rely on custom metadata `version` headers to allow resuming downloads, rather than the ETag(?)...