### PR TITLE
impl HttpError::new_boxed to provide user with ability to ctor from already boxed error

### DIFF
--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -81,10 +81,13 @@ impl HttpError {
     where
         E: Error + Send + Sync + 'static,
     {
-        Self {
-            kind,
-            source: Box::new(e),
-        }
+        Self::new_boxed(kind, Box::new(e))
+    }
+
+    #[inline]
+    /// Create a new [`HttpError`] with provided `source` error
+    pub fn new_boxed(kind: HttpErrorKind, source: Box<dyn Error + Send + Sync>) -> Self {
+        Self { kind, source }
     }
 
     #[cfg(feature = "reqwest")]


### PR DESCRIPTION
# Which issue does this PR close?

None, it is minor improvement to API

# Rationale for this change
 
I would like to be able to created HttpError from already boxed error for my alternative HTTP client implementation
Otherwise I need to wrap boxed error into new type

# What changes are included in this PR?

Introduces new method to HttpError to create error from boxed `dyn std::error::Error`

# Are there any user-facing changes?

New public method on `HttpError`
No breaking changes