### PR TITLE
chore: reduce lock hold time in DefaultObjectStoreRegistry::deregister

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -263,9 +263,9 @@ impl ObjectStoreRegistry for DefaultObjectStoreRegistry {
     }
 
     fn deregister(&self, url: &Url) -> Option<Arc<dyn ObjectStore>> {
-        let mut map = self.map.write();
         let key = url_key(url);
         let segments: Vec<&str> = path_segments(url.path()).collect();
+        let mut map = self.map.write();
         let entry = map.get_mut(key)?;
         let removed = entry.remove(&segments);
         // Drop the authority entry entirely once it holds no stores.


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

`deregister` acquired the write lock before computing the URL key and
path segments, unnecessarily extending the time the lock is held.

# What changes are included in this PR?

Move the `url_key` and path segment computation ahead of the write
lock acquisition in `DefaultObjectStoreRegistry::deregister`, so the
lock is only held for the actual map mutation.

# Are there any user-facing changes?

No.