### PR TITLE
Update release process to use RC tags

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -110,28 +110,29 @@ create a release candidate using the following steps. Note you need to
 be a committer to run these scripts as they upload to the apache `svn`
 distribution servers.
 
-### Create git tag for the release:
-
-While the official release artifact is a signed tarball, we also tag the commit it was created for convenience and code archaeology.
-
-Use a string such as `v0.4.0` as the `<version>`.
-
-Create and push the tag thusly:
-
-```shell
-git fetch apache
-git tag <version> apache/main
-# push tag to apache
-git push apache <version>
-```
-
-### Pick an Release Candidate (RC) number
+### Pick a Release Candidate (RC) number
 
 Pick numbers in sequential order, with `1` for `rc1`, `2` for `rc2`, etc.
 
+### Create git tag for the release candidate:
+
+While the official release artifact is a signed tarball, we also tag the commit it was created for convenience and code archaeology.
+
+Use a string such as `0.4.0` as the `<version>`.
+
+Create and push an RC tag thusly. For example, version `0.4.0` and RC
+number `2` would be `v0.4.0-rc2`:
+
+```shell
+git fetch apache
+git tag v<version>-rc<rc> apache/main
+# push tag to apache
+git push apache v<version>-rc<rc>
+```
+
 ### Create, sign, and upload tarball
 
-Run `create-tarball.sh` with the `<version>` tag and `<rc>` and you found in previous steps.
+Run `create-tarball.sh` with the `<version>` and `<rc>` you found in previous steps.
 
 ```shell
 ./dev/release/create-tarball.sh 0.11.1 1
@@ -148,41 +149,8 @@ The `create-tarball.sh` script
 
 ### Vote on Release Candidate tarball
 
-Send an email, based on the output from the script to dev@arrow.apache.org. The email should look like
-
-```
-Draft email for dev@arrow.apache.org mailing list
-
----------------------------------------------------------
-To: dev@arrow.apache.org
-Subject: [VOTE][RUST] Release Apache Arrow Rust Object Store 0.11.1 RC1
-
-Hi,
-
-I would like to propose a release of Apache Arrow Rust Object
-Store Implementation, version 0.11.1.
-
-This release candidate is based on commit: b945b15de9085f5961a478d4f35b0c5c3427e248 [1]
-
-The proposed release tarball and signatures are hosted at [2].
-
-The changelog is located at [3].
-
-Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. There is a script [4] that automates some of
-the verification.
-
-The vote will be open for at least 72 hours.
-
-[ ] +1 Release this as Apache Arrow Rust Object Store
-[ ] +0
-[ ] -1 Do not release this as Apache Arrow Rust Object Store  because...
-
-[1]: https://github.com/apache/arrow-rs-object-store/tree/b945b15de9085f5961a478d4f35b0c5c3427e248
-[2]: https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-object-store-rs-0.11.1-rc1/
-[3]: https://github.com/apache/arrow-rs-object-store/blob/b945b15de9085f5961a478d4f35b0c5c3427e248/CHANGELOG.md
-[4]: https://github.com/apache/arrow-rs-object-store/blob/main/dev/release/verify-release-candidate.sh
-```
+Send an email, based on the output from the script to dev@arrow.apache.org.
+See an [example of how the email should look](https://lists.apache.org/thread/29v3kjk5x6nlqrgt1kq6c7o8km0wn1w9).
 
 For the release to become "official" it needs at least three Apache Arrow PMC members to vote +1 on it.
 
@@ -200,7 +168,19 @@ If the release is not approved, fix whatever the problem is and try again with t
 
 ### If the release is approved,
 
-Move tarball to the release location in SVN, e.g. https://dist.apache.org/repos/dist/release/arrow/apache-arrow-object-store-rs-4.1.0-rc4/, using the `release-tarball.sh` script:
+Then, create a new release on GitHub using the tag `v<version>` (e.g.
+`v4.1.0`).
+
+Push the release tag to GitHub:
+
+```shell
+git tag v<version> v<version>-rc<rc>
+git push apache v<version>
+```
+
+Move tarball to the release location in SVN, e.g.
+https://dist.apache.org/repos/dist/release/arrow/arrow-object-store-rs-4.1.0/,
+using the `release-tarball.sh` script:
 
 ```shell
 ./dev/release/release-tarball.sh 4.1.0 2

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -24,7 +24,7 @@
 # email for sending to the dev@arrow.apache.org list for a formal
 # vote.
 #
-# Note the tags are expected to be `object_sore_<version>`
+# Note the tags are expected to be `v<version>-rc<rc>`
 #
 # See release/README.md for full release instructions
 #
@@ -53,7 +53,7 @@ fi
 
 object_store_version=$1
 rc=$2
-tag=v${object_store_version}
+tag=v${object_store_version}-rc${rc}
 
 release=apache-arrow-object-store-rs-${object_store_version}
 distdir=${SOURCE_TOP_DIR}/dev/dist/${release}-rc${rc}
@@ -61,52 +61,15 @@ tarname=${release}.tar.gz
 tarball=${distdir}/${tarname}
 url="https://dist.apache.org/repos/dist/dev/arrow/${release}-rc${rc}"
 
-echo "Attempting to create ${tarball} from tag ${tag}"
-
-release_hash=$(cd "${SOURCE_TOP_DIR}" && git rev-list --max-count=1 ${tag})
-
-if [ -z "$release_hash" ]; then
+if ! release_hash=$(cd "${SOURCE_TOP_DIR}" && git rev-list --max-count=1 ${tag} 2>/dev/null); then
     echo "Cannot continue: unknown git tag: $tag"
+    exit 1
 fi
 
-echo "Draft email for dev@arrow.apache.org mailing list"
-echo ""
-echo "---------------------------------------------------------"
-cat <<MAIL
-To: dev@arrow.apache.org
-Subject: [VOTE][RUST] Release Apache Arrow Rust Object Store ${object_store_version} RC${rc}
-
-Hi,
-
-I would like to propose a release of Apache Arrow Rust Object
-Store Implementation, version ${object_store_version}.
-
-This release candidate is based on commit: ${release_hash} [1]
-
-The proposed release tarball and signatures are hosted at [2].
-
-The changelog is located at [3].
-
-Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. There is a script [4] that automates some of
-the verification.
-
-The vote will be open for at least 72 hours.
-
-[ ] +1 Release this as Apache Arrow Rust Object Store ${version}
-[ ] +0
-[ ] -1 Do not release this as Apache Arrow Rust Object Store ${version} because...
-
-[1]: https://github.com/apache/arrow-rs-object-store/tree/${release_hash}
-[2]: ${url}
-[3]: https://github.com/apache/arrow-rs-object-store/blob/${release_hash}/CHANGELOG.md
-[4]: https://github.com/apache/arrow-rs-object-store/blob/main/dev/release/verify-release-candidate.sh
-MAIL
-echo "---------------------------------------------------------"
-
+echo "Attempting to create ${tarball} from tag ${tag}"
 
 # create <tarball> containing the files in git at $release_hash
-# the files in the tarball are prefixed with {tag=} (e.g. 0.4.0)
+# the files in the tarball are prefixed with {release} (e.g. apache-arrow-object-store-rs-0.4.0)
 mkdir -p ${distdir}
 (cd "${SOURCE_TOP_DIR}" && git archive ${release_hash} --prefix ${release}/ | gzip > ${tarball})
 
@@ -120,6 +83,46 @@ gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
 #  shasum --check apache-arrow-rs-4.1.0-rc2.tar.gz.sha512
 (cd ${distdir} && shasum -a 256 ${tarname}) > ${tarball}.sha256
 (cd ${distdir} && shasum -a 512 ${tarname}) > ${tarball}.sha512
+sha256=$(cut -d ' ' -f 1 "${tarball}.sha256")
+
+echo "Draft email for dev@arrow.apache.org mailing list"
+echo ""
+echo "---------------------------------------------------------"
+cat <<MAIL
+To: dev@arrow.apache.org
+Subject: [VOTE][RUST] Release Apache Arrow Rust Object Store ${object_store_version} RC${rc}
+
+Hi,
+
+I would like to propose a release of Apache Arrow Rust Object
+Store Implementation, version ${object_store_version}.
+
+This release candidate is based on commit: ${release_hash} [1].
+The SHA256 of the release candidate is: ${sha256}
+
+The proposed release tarball and signatures are hosted at [2].
+
+The changelog is located at [3].
+
+The release tracking issue is: [5]
+
+Please download, verify checksums and signatures, run the unit tests,
+and vote on the release. There is a script [4] that automates some of
+the verification.
+
+The vote will be open for at least 72 hours.
+
+[ ] +1 Release this as Apache Arrow Rust Object Store ${object_store_version}
+[ ] +0
+[ ] -1 Do not release this as Apache Arrow Rust Object Store ${object_store_version} because...
+
+[1]: https://github.com/apache/arrow-rs-object-store/tree/${release_hash}
+[2]: ${url}
+[3]: https://github.com/apache/arrow-rs-object-store/blob/${release_hash}/CHANGELOG.md
+[4]: https://github.com/apache/arrow-rs-object-store/blob/main/dev/release/verify-release-candidate.sh
+[5]: RELEASE_ISSUE
+MAIL
+echo "---------------------------------------------------------"
 
 echo "Uploading to apache dist/dev to ${url}"
 svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow ${SOURCE_TOP_DIR}/dev/dist


### PR DESCRIPTION
# Which issue does this PR close?

Closes #775.

# Rationale for this change

Pushing release tags like `vX.Y.Z` during release candidate preparation can make an unapproved release candidate look like an official release before the ASF vote has passed.

This updates the release process to follow the same RC-tag model used by arrow-rs: use an RC tag while preparing and voting on a release candidate, then create the final release tag only after the release is approved.

# What changes are included in this PR?

- Update `dev/release/README.md` to create and push `v<version>-rc<rc>` tags for release candidates.
- Update `dev/release/create-tarball.sh` to build the release candidate tarball from the RC tag.
- Move tarball creation before printing the vote email so the generated email can include the exact release candidate commit and SHA256.
- Update the generated vote email to include the release tracking issue placeholder and match the current arrow-rs-style vote email.
- Document creating the final `v<version>` tag only after approval.

I plan to use these instructions during the upcoming 0.14.1 release tracked in #761 and adjust accordingly if anything needs refinement.

# Are there any user-facing changes?

No crate API or runtime behavior changes.

This changes release-manager-facing documentation and scripts so GitHub Releases are not created before ASF approval.
