### PR TITLE
Create GitHub releases automatically on tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Creates a github release on https://github.com/apache/arrow-rs-object-store/releases
+# when a non-RC release tag is pushed to the repository.
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!*-rc*'
+permissions:
+  contents: write
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Create GitHub Release
+        run: |
+          version=${GITHUB_REF_NAME}
+          title="object_store ${version}"
+          notes_file=CHANGELOG.md
+          gh release create ${GITHUB_REF_NAME} \
+            --title "${title}" \
+            --notes-file ${notes_file} \
+            --verify-tag

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -208,6 +208,15 @@ Move tarball to the release location in SVN, e.g. https://dist.apache.org/repos/
 
 Congratulations! The release is now official!
 
+### Check the GitHub release
+
+The [`release.yml`] workflow automatically creates a GitHub release for
+non-RC `v*` tags. Check that the release is created and contains the
+correct changelog here:
+https://github.com/apache/arrow-rs-object-store/releases
+
+[`release.yml`]: https://github.com/apache/arrow-rs-object-store/blob/main/.github/workflows/release.yml#L1-L0
+
 ### Publish on Crates.io
 
 Only approved releases of the tarball should be published to


### PR DESCRIPTION
# Which issue does this PR close?

Follow-on to 
 - #775 
 - #796

# Rationale for this change

This does the same thing as @kou did in apache/arrow-rs#7042 for arrow-rs-object-store: it creates GitHub Releases automatically when release tags are pushed.

This should be used with the RC-tag release flow from #796, so only the final post-approval `v<version>` tag creates a GitHub Release.

# What changes are included in this PR?

- Add a GitHub Actions workflow that creates a GitHub Release automatically when a release tag is pushed.
- Follow the current arrow-rs release flow:
  - https://github.com/apache/arrow-rs/blob/main/.github/workflows/release.yml
  - https://github.com/apache/arrow-rs/blob/main/dev/release/README.md
- Update the object-store release instructions to check the generated GitHub Release.

I think we will have to test this live when the next final release tag is pushed.

# Are there any user-facing changes?

No crate API or runtime behavior changes.

This adds release-manager-facing automation so final GitHub Releases are created automatically after approved release tags are pushed.
