### PR TITLE
Pin Rust toolchain to 1.97.0 and fix clippy

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]

--- a/src/azure/builder.rs
+++ b/src/azure/builder.rs
@@ -1266,9 +1266,9 @@ impl MicrosoftAzureBuilder {
                 Some(account_url) => account_url,
                 None => match self.use_fabric_endpoint.get()? {
                     true => {
-                        format!("https://{}.blob.fabric.microsoft.com", &account_name)
+                        format!("https://{}.blob.fabric.microsoft.com", account_name)
                     }
-                    false => format!("https://{}.blob.core.windows.net", &account_name),
+                    false => format!("https://{}.blob.core.windows.net", account_name),
                 },
             };
 

--- a/src/azure/credential.rs
+++ b/src/azure/credential.rs
@@ -441,18 +441,18 @@ fn string_to_sign_service_sas(
         signed_start,
         signed_expiry,
         canonicalized_resource,
-        "",                               // signed identifier
-        "",                               // signed ip
-        "",                               // signed protocol
-        &AZURE_VERSION.to_str().unwrap(), // signed version
-        signed_resource,                  // signed resource
-        "",                               // signed snapshot time
-        "",                               // signed encryption scope
-        "",                               // rscc - response header: Cache-Control
-        "",                               // rscd - response header: Content-Disposition
-        "",                               // rsce - response header: Content-Encoding
-        "",                               // rscl - response header: Content-Language
-        "",                               // rsct - response header: Content-Type
+        "",                              // signed identifier
+        "",                              // signed ip
+        "",                              // signed protocol
+        AZURE_VERSION.to_str().unwrap(), // signed version
+        signed_resource,                 // signed resource
+        "",                              // signed snapshot time
+        "",                              // signed encryption scope
+        "",                              // rscc - response header: Cache-Control
+        "",                              // rscd - response header: Content-Disposition
+        "",                              // rsce - response header: Content-Encoding
+        "",                              // rscl - response header: Content-Language
+        "",                              // rsct - response header: Content-Type
     );
 
     let mut pairs = HashMap::new();
@@ -485,26 +485,26 @@ fn string_to_sign_user_delegation_sas(
         signed_start,
         signed_expiry,
         canonicalized_resource,
-        delegation_key.signed_oid,        // signed key object id
-        delegation_key.signed_tid,        // signed key tenant id
-        delegation_key.signed_start,      // signed key start
-        delegation_key.signed_expiry,     // signed key expiry
-        delegation_key.signed_service,    // signed key service
-        delegation_key.signed_version,    // signed key version
-        "",                               // signed authorized user object id
-        "",                               // signed unauthorized user object id
-        "",                               // signed correlation id
-        "",                               // signed ip
-        "",                               // signed protocol
-        &AZURE_VERSION.to_str().unwrap(), // signed version
-        signed_resource,                  // signed resource
-        "",                               // signed snapshot time
-        "",                               // signed encryption scope
-        "",                               // rscc - response header: Cache-Control
-        "",                               // rscd - response header: Content-Disposition
-        "",                               // rsce - response header: Content-Encoding
-        "",                               // rscl - response header: Content-Language
-        "",                               // rsct - response header: Content-Type
+        delegation_key.signed_oid,       // signed key object id
+        delegation_key.signed_tid,       // signed key tenant id
+        delegation_key.signed_start,     // signed key start
+        delegation_key.signed_expiry,    // signed key expiry
+        delegation_key.signed_service,   // signed key service
+        delegation_key.signed_version,   // signed key version
+        "",                              // signed authorized user object id
+        "",                              // signed unauthorized user object id
+        "",                              // signed correlation id
+        "",                              // signed ip
+        "",                              // signed protocol
+        AZURE_VERSION.to_str().unwrap(), // signed version
+        signed_resource,                 // signed resource
+        "",                              // signed snapshot time
+        "",                              // signed encryption scope
+        "",                              // rscc - response header: Cache-Control
+        "",                              // rscd - response header: Content-Disposition
+        "",                              // rsce - response header: Content-Encoding
+        "",                              // rscl - response header: Content-Language
+        "",                              // rsct - response header: Content-Type
     );
 
     let mut pairs = HashMap::new();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #798.

# Rationale for this change

Clippy started failing on `main` after the release of Rust 1.97.0, 

To avoid being surprised by new lints in future toolchain releases (and to make CI reproducible), this PR also pins the Rust toolchain, mirroring the approach used in [apache/arrow-rs](https://github.com/apache/arrow-rs/blob/main/rust-toolchain.toml).

# What changes are included in this PR?

1. Add a `rust-toolchain.toml` pinning the toolchain to `1.97.0`
2. Fix the  clippy failures 

# Are there any user-facing changes?

No.
