### PR TITLE
fix: support File payloads in ThrottledStore (fixes LocalFileSystem panic)

### DIFF
--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -181,7 +181,7 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         let wait_get_per_byte = self.config().wait_get_per_byte;
 
         let result = self.inner.get_opts(location, options).await?;
-        Ok(throttle_get(result, wait_get_per_byte))
+        Ok(throttle_get(result, wait_get_per_byte).await)
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
@@ -270,22 +270,34 @@ fn usize_to_u32_saturate(x: usize) -> u32 {
     x.try_into().unwrap_or(u32::MAX)
 }
 
-fn throttle_get(result: GetResult, wait_get_per_byte: Duration) -> GetResult {
-    #[allow(clippy::infallible_destructuring_match)]
-    let s = match result.payload {
-        GetResultPayload::Stream(s) => s,
+async fn throttle_get(result: GetResult, wait_get_per_byte: Duration) -> GetResult {
+    match result.payload {
+        GetResultPayload::Stream(s) => {
+            let stream = throttle_stream(s, move |bytes| {
+                let bytes_len: u32 = usize_to_u32_saturate(bytes.len());
+                wait_get_per_byte * bytes_len
+            });
+
+            GetResult {
+                payload: GetResultPayload::Stream(stream),
+                ..result
+            }
+        }
+        // A File payload has no byte stream to lazily wrap, so we cannot apply the
+        // per-byte throttle per chunk as we do for streams. Rather than force the
+        // file into a stream (and lose the local-file fast path that callers rely
+        // on), sleep once up front for the per-byte cost of the whole requested
+        // range, mirroring how `get_ranges` throttles, and return the File payload
+        // untouched. When `wait_get_per_byte` is zero this is a no-op and the File
+        // payload passes straight through.
         #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
-        GetResultPayload::File(_, _) => unimplemented!(),
-    };
+        payload @ GetResultPayload::File(_, _) => {
+            let n_bytes = result.range.end - result.range.start;
+            let n_bytes: u32 = n_bytes.try_into().unwrap_or(u32::MAX);
+            sleep(wait_get_per_byte * n_bytes).await;
 
-    let stream = throttle_stream(s, move |bytes| {
-        let bytes_len: u32 = usize_to_u32_saturate(bytes.len());
-        wait_get_per_byte * bytes_len
-    });
-
-    GetResult {
-        payload: GetResultPayload::Stream(stream),
-        ..result
+            GetResult { payload, ..result }
+        }
     }
 }
 
@@ -539,6 +551,37 @@ mod tests {
 
         store.config_mut(|cfg| cfg.wait_put_per_call = ZERO);
         assert_bounds!(measure_put(&store, 0).await, 0);
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
+    async fn get_local_file_system() {
+        use crate::local::LocalFileSystem;
+
+        // `LocalFileSystem::get_opts` returns a `GetResultPayload::File`, which the
+        // throttling wrapper previously handled with `unimplemented!()`, panicking on
+        // the first `get`. Wrapping it in a `ThrottledStore` and reading an object back
+        // must work and return the correct bytes.
+        let root = tempfile::TempDir::new().unwrap();
+        let inner = LocalFileSystem::new_with_prefix(root.path()).unwrap();
+        let store = ThrottledStore::new(inner, ThrottleConfig::default());
+
+        let path = Path::from("file.txt");
+        let data = Bytes::from_static(b"hello world");
+        store.put(&path, data.clone().into()).await.unwrap();
+
+        // Exercise both the per-call and per-byte throttle components against a File payload.
+        store.config_mut(|cfg| {
+            cfg.wait_get_per_call = Duration::from_millis(1);
+            cfg.wait_get_per_byte = Duration::from_millis(1);
+        });
+
+        let result = store.get(&path).await.unwrap();
+        // The File fast path is preserved rather than being converted into a stream.
+        assert!(matches!(&result.payload, GetResultPayload::File(_, _)));
+
+        let received = result.bytes().await.unwrap();
+        assert_eq!(received, data);
     }
 
     async fn place_test_object(store: &ThrottledStore<InMemory>, n_bytes: Option<usize>) -> Path {


### PR DESCRIPTION
# Which issue does this PR close?

No separate issue is filed; the bug and repro are described in full below.

# Rationale for this change

`ThrottledStore` is the crate's built-in wrapper for performance testing (it injects `wait_get_per_call` first-byte latency, `wait_get_per_byte` throughput throttling, and so on). But it panics with `not implemented` on the first `get`/`get_opts`/`head` when it wraps a store that returns a file-backed payload, which is exactly what `LocalFileSystem` does when the `fs` feature is enabled, and `LocalFileSystem` is the obvious inner store you would want to throttle for perf testing.

Every `get_opts` result is funnelled through the free function `throttle_get` in `src/throttle.rs`, whose payload match was:

```rust
GetResultPayload::File(_, _) => unimplemented!(),
```

`LocalFileSystem::get_opts` returns `GetResultPayload::File(..)`, so the first read hits `unimplemented!()`.

Note that the fixed per-call latency already worked for File payloads (`sleep(wait_get_per_call)` runs before the inner call in `get_opts`), and `get_ranges` already worked (it delegates directly). Only the per-byte stream-wrapping step in `throttle_get` panicked.

Minimal repro:

```rust
use object_store::{throttle::{ThrottledStore, ThrottleConfig}, local::LocalFileSystem, ObjectStore, path::Path};

let dir = tempfile::TempDir::new().unwrap();
let store = ThrottledStore::new(
    LocalFileSystem::new_with_prefix(dir.path()).unwrap(),
    ThrottleConfig::default(),
);
let path = Path::from("file.txt");
store.put(&path, "hello".into()).await.unwrap();
store.get(&path).await.unwrap(); // panics: not implemented
```

# What changes are included in this PR?

`throttle_get` now handles the File payload instead of panicking. The design preserves the local-file fast path rather than forcing every File read into a byte stream just so it can be throttled:

- For a `Stream` payload, behavior is byte-for-byte unchanged: the per-byte throttle is applied lazily per chunk as before.
- For a `File` payload, the per-byte component is applied as a single eager sleep computed from the known requested range (`result.range`), mirroring how `get_ranges` already throttles a whole vectored read up front, and then the File payload is returned untouched. Because `sleep` is a no-op on a zero duration, the common case where only `wait_get_per_call` is set (and `wait_get_per_byte` is zero) passes the File payload straight through with no allocation or stream conversion.

`throttle_get` becomes `async` so the File-path sleep can be awaited; the single caller in `get_opts` awaits it.

A regression test (`get_local_file_system`) wraps a real `LocalFileSystem` in a `ThrottledStore` with non-zero per-call and per-byte waits, reads an object back, asserts the payload is still a `File` (fast path preserved), and asserts the bytes are correct. This test panics on the previous code and passes now.

# Are there any user-facing changes?

Yes, a bug fix: `ThrottledStore` no longer panics when wrapping a store that returns a `GetResultPayload::File` (e.g. `LocalFileSystem`). No public API changes; `throttle_get` is a private function.
