### PR TITLE
fix: restore 1.85 MSRV and fix MSRV CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Check
         run: |
           # run `cargo msrv verify` to see problems
-          cargo msrv verify --output-format=json || exit 1
+          cargo msrv verify --all-features --output-format=json || exit 1

--- a/src/client/token.rs
+++ b/src/client/token.rs
@@ -78,18 +78,18 @@ impl<T: Clone + Send + Sync> TokenCache<T> {
             })
         };
 
-        if let Some(cache) = self.cache.read().await.as_ref()
-            && is_token_valid(cache)
-        {
-            return Ok(cache.token.token.clone());
+        if let Some(cache) = self.cache.read().await.as_ref() {
+            if is_token_valid(cache) {
+                return Ok(cache.token.token.clone());
+            }
         }
 
         let mut guard = self.cache.write().await;
-        if let Some(cache) = guard.as_ref()
-            && is_token_valid(cache)
-        {
-            // Refresh race
-            return Ok(cache.token.token.clone());
+        if let Some(cache) = guard.as_ref() {
+            if is_token_valid(cache) {
+                // Refresh race
+                return Ok(cache.token.token.clone());
+            }
         }
 
         let cached = f().await?;


### PR DESCRIPTION
- Closes https://github.com/apache/arrow-rs-object-store/issues/811

This just avoids using let chains, which were introduced in 1.88 or something.
