### PR TITLE
Support streaming put payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,11 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 serde_urlencoded = { version = "0.7", optional = true }
 
 # Optional tokio feature
-tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"], optional = true }
+tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"], optional = true }
 tracing = { version = "0.1", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.29.0", features = ["fs"], optional = true }
 
 [target.'cfg(target_family="unix")'.dependencies]
 nix = { version = "0.31.1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 serde_urlencoded = { version = "0.7", optional = true }
 
 # Optional tokio feature
-tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util"], optional = true }
+tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"], optional = true }
 tracing = { version = "0.1", optional = true }
 
 [target.'cfg(target_family="unix")'.dependencies]

--- a/src/aws/client.rs
+++ b/src/aws/client.rs
@@ -405,40 +405,65 @@ impl Request<'_> {
         Self { builder, ..self }
     }
 
-    pub(crate) fn with_payload(mut self, payload: PutPayload) -> Result<Self> {
-        let mut cached_digest: Option<[u8; 32]> = None;
-        let mut sha256_digest = || -> Result<[u8; 32]> {
-            if let Some(digest) = cached_digest {
-                return Ok(digest);
+    pub(crate) async fn with_payload(mut self, payload: PutPayload) -> Result<Self> {
+        use futures_util::TryStreamExt;
+
+        let needs_sha256 = (!self.config.skip_signature && self.config.sign_payload)
+            || self.config.checksum == Some(Checksum::SHA256);
+        let mut sha256 = needs_sha256
+            .then(|| self.config.crypto()?.digest(DigestAlgorithm::Sha256))
+            .transpose()?;
+        let mut crc64 = (self.config.checksum == Some(Checksum::CRC64NVME)).then(|| {
+            let algorithm = crc_fast::CrcAlgorithm::Crc64Nvme;
+            crc_fast::Digest::new(algorithm)
+        });
+
+        if sha256.is_some() || crc64.is_some() {
+            let mut update_hashes = |part: &[u8]| {
+                if let Some(digest) = &mut sha256 {
+                    digest.update(part);
+                }
+                if let Some(digest) = &mut crc64 {
+                    digest.update(part);
+                }
+            };
+
+            if payload.is_streaming() {
+                let mut stream = payload.stream().map_err(|source| crate::Error::Generic {
+                    store: "S3",
+                    source,
+                });
+                while let Some(part) = stream.try_next().await? {
+                    update_hashes(&part);
+                }
+            } else {
+                for part in &payload {
+                    update_hashes(part);
+                }
             }
-            let mut ctx = self.config.crypto()?.digest(DigestAlgorithm::Sha256)?;
-            for part in &payload {
-                ctx.update(part);
-            }
-            let digest = ctx.finish()?.try_into().unwrap();
-            cached_digest = Some(digest);
-            Ok(digest)
+        }
+
+        let sha256_digest = match sha256 {
+            Some(mut digest) => Some(digest.finish()?.try_into().unwrap()),
+            None => None,
         };
+        let crc64_checksum = crc64.map(|digest| digest.finalize());
 
         if !self.config.skip_signature && self.config.sign_payload {
-            self.payload_sha256 = Some(sha256_digest()?);
+            self.payload_sha256 = sha256_digest;
         }
 
         match self.config.checksum {
             Some(Checksum::SHA256) => {
-                self.builder = self
-                    .builder
-                    .header(SHA256_CHECKSUM, BASE64_STANDARD.encode(sha256_digest()?));
+                self.builder = self.builder.header(
+                    SHA256_CHECKSUM,
+                    BASE64_STANDARD.encode(sha256_digest.unwrap()),
+                );
             }
             Some(Checksum::CRC64NVME) => {
-                let crc_algo = crc_fast::CrcAlgorithm::Crc64Nvme;
-                let mut digest = crc_fast::Digest::new(crc_algo);
-                payload.iter().for_each(|x| digest.update(x));
-                let checksum = digest.finalize();
-
                 self.builder = self.builder.header(
                     CRC64NVME_CHECKSUM,
-                    BASE64_STANDARD.encode(checksum.to_be_bytes()),
+                    BASE64_STANDARD.encode(crc64_checksum.unwrap().to_be_bytes()),
                 )
             }
             None => {}
@@ -754,7 +779,7 @@ impl S3Client {
             .idempotent(true);
 
         request = match data {
-            PutPartPayload::Part(payload) => request.with_payload(payload)?,
+            PutPartPayload::Part(payload) => request.with_payload(payload).await?,
             PutPartPayload::Copy(path) => request.header(
                 "x-amz-copy-source",
                 &format!("{}/{}", self.config.bucket, encode_path(path)),
@@ -1164,6 +1189,42 @@ mod tests {
         }
     }
 
+    #[cfg(all(feature = "reqwest", any(feature = "aws-lc-rs", feature = "ring")))]
+    #[tokio::test]
+    async fn test_payload_hashes_share_stream_pass() {
+        use std::io;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mock = MockServer::new().await;
+        let mut config = default_headers_config(&mock);
+        config.sign_payload = true;
+        config.checksum = Some(Checksum::CRC64NVME);
+        let client = S3Client::new(config, HttpClient::new(reqwest::Client::new()));
+
+        let stream_count = Arc::new(AtomicUsize::new(0));
+        let payload = PutPayload::from_stream(
+            {
+                let stream_count = Arc::clone(&stream_count);
+                move || {
+                    stream_count.fetch_add(1, Ordering::SeqCst);
+                    futures_util::stream::once(async {
+                        Ok::<_, io::Error>(Bytes::from_static(b"payload"))
+                    })
+                }
+            },
+            7,
+        );
+
+        client
+            .request(Method::PUT, &Path::from("test"))
+            .with_payload(payload)
+            .await
+            .unwrap();
+
+        assert_eq!(stream_count.load(Ordering::SeqCst), 1);
+        mock.shutdown().await;
+    }
+
     #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn test_default_headers_signed_request() {
@@ -1182,6 +1243,7 @@ mod tests {
         let result = client
             .request(Method::PUT, &Path::from("test"))
             .with_payload(PutPayload::default())
+            .await
             .unwrap()
             .do_put()
             .await;

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -177,7 +177,8 @@ impl ObjectStore for AmazonS3 {
         let request = self
             .client
             .request(Method::PUT, location)
-            .with_payload(payload)?
+            .with_payload(payload)
+            .await?
             .with_attributes(attributes)
             .with_tags(tags)
             .with_extensions(extensions)

--- a/src/client/http/body.rs
+++ b/src/client/http/body.rs
@@ -18,8 +18,8 @@
 use crate::client::{HttpError, HttpErrorKind};
 use crate::{PutPayload, collect_bytes};
 use bytes::Bytes;
-use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
+use futures_util::{StreamExt, TryStreamExt};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Body, Frame, SizeHint};
@@ -30,8 +30,16 @@ use std::task::{Context, Poll};
 pub type HttpRequest = http::Request<HttpRequestBody>;
 
 /// The [`Body`] of an [`HttpRequest`]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HttpRequestBody(Inner);
+
+impl std::fmt::Debug for HttpRequestBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpRequestBody")
+            .field("content_length", &self.content_length())
+            .finish()
+    }
+}
 
 impl HttpRequestBody {
     /// An empty [`HttpRequestBody`]
@@ -46,6 +54,11 @@ impl HttpRequestBody {
             Inner::PutPayload(_, payload) => reqwest::Body::wrap_stream(
                 futures_util::stream::iter(payload.into_iter().map(Ok::<_, HttpError>)),
             ),
+            Inner::Streaming(body) => reqwest::Body::wrap_stream(
+                body.payload
+                    .stream()
+                    .map_err(|e| HttpError::new_boxed(HttpErrorKind::Unknown, e)),
+            ),
         }
     }
 
@@ -54,6 +67,7 @@ impl HttpRequestBody {
         match self.0 {
             Inner::Bytes(b) => b.into(),
             Inner::PutPayload(_, payload) => Bytes::from(payload).into(),
+            Inner::Streaming(body) => Bytes::from(body.payload).into(),
         }
     }
 
@@ -62,6 +76,7 @@ impl HttpRequestBody {
         match &self.0 {
             Inner::Bytes(x) => x.is_empty(),
             Inner::PutPayload(_, x) => x.iter().any(|x| !x.is_empty()),
+            Inner::Streaming(x) => x.payload.content_length() != 0,
         }
     }
 
@@ -70,6 +85,7 @@ impl HttpRequestBody {
         match &self.0 {
             Inner::Bytes(x) => x.len(),
             Inner::PutPayload(_, x) => x.content_length(),
+            Inner::Streaming(x) => x.payload.content_length(),
         }
     }
 
@@ -102,14 +118,41 @@ impl From<String> for HttpRequestBody {
 
 impl From<PutPayload> for HttpRequestBody {
     fn from(value: PutPayload) -> Self {
-        Self(Inner::PutPayload(0, value))
+        match value.is_streaming() {
+            false => Self(Inner::PutPayload(0, value)),
+            true => Self(Inner::Streaming(PutPayloadBody {
+                payload: value,
+                stream: None,
+                bytes_read: 0,
+                finished: false,
+            })),
+        }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 enum Inner {
     Bytes(Bytes),
     PutPayload(usize, PutPayload),
+    Streaming(PutPayloadBody),
+}
+
+struct PutPayloadBody {
+    payload: PutPayload,
+    stream: Option<BoxStream<'static, Result<Bytes, HttpError>>>,
+    bytes_read: usize,
+    finished: bool,
+}
+
+impl Clone for PutPayloadBody {
+    fn clone(&self) -> Self {
+        Self {
+            payload: self.payload.clone(),
+            stream: None,
+            bytes_read: 0,
+            finished: false,
+        }
+    }
 }
 
 impl Body for HttpRequestBody {
@@ -118,7 +161,7 @@ impl Body for HttpRequestBody {
 
     fn poll_frame(
         mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         Poll::Ready(match &mut self.0 {
             Inner::Bytes(bytes) => {
@@ -139,6 +182,29 @@ impl Body for HttpRequestBody {
                     )))
                 }
             }
+            Inner::Streaming(body) => {
+                let stream = body.stream.get_or_insert_with(|| {
+                    body.payload
+                        .stream()
+                        .map_err(|e| HttpError::new_boxed(HttpErrorKind::Unknown, e))
+                        .boxed()
+                });
+                match futures_core::Stream::poll_next(Pin::new(stream), cx) {
+                    Poll::Ready(Some(Ok(bytes))) => {
+                        body.bytes_read += bytes.len();
+                        return Poll::Ready(Some(Ok(Frame::data(bytes))));
+                    }
+                    Poll::Ready(Some(Err(e))) => {
+                        body.finished = true;
+                        Some(Err(e))
+                    }
+                    Poll::Ready(None) => {
+                        body.finished = true;
+                        None
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
         })
     }
 
@@ -146,6 +212,7 @@ impl Body for HttpRequestBody {
         match self.0 {
             Inner::Bytes(ref bytes) => bytes.is_empty(),
             Inner::PutPayload(offset, ref body) => offset == body.as_ref().len(),
+            Inner::Streaming(ref body) => body.finished,
         }
     }
 
@@ -156,6 +223,11 @@ impl Body for HttpRequestBody {
                 let iter = payload.as_ref().iter().skip(offset);
                 SizeHint::with_exact(iter.map(|x| x.len() as u64).sum())
             }
+            Inner::Streaming(ref body) => SizeHint::with_exact(
+                body.payload
+                    .content_length()
+                    .saturating_sub(body.bytes_read) as u64,
+            ),
         }
     }
 }
@@ -238,5 +310,37 @@ impl From<Vec<u8>> for HttpResponseBody {
 impl From<String> for HttpResponseBody {
     fn from(value: String) -> Self {
         Bytes::from(value).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn byte_backed_put_payload_uses_synchronous_body() {
+        let body = HttpRequestBody::from(PutPayload::from_static(b"payload"));
+        assert!(matches!(&body.0, Inner::PutPayload(0, _)));
+    }
+
+    #[tokio::test]
+    async fn streaming_request_body_clone_is_replayable() {
+        let payload = PutPayload::from_stream(
+            || {
+                futures_util::stream::iter([
+                    Ok::<_, io::Error>(Bytes::from_static(b"hello ")),
+                    Ok(Bytes::from_static(b"world")),
+                ])
+            },
+            11,
+        );
+
+        let body = HttpRequestBody::from(payload);
+        assert!(matches!(&body.0, Inner::Streaming(_)));
+        for body in [body.clone(), body] {
+            assert_eq!(body.content_length(), 11);
+            assert_eq!(body.collect().await.unwrap().to_bytes(), "hello world");
+        }
     }
 }

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -541,6 +541,62 @@ mod tests {
         assert!(!body_contains_error(success_response));
     }
 
+    #[cfg(all(
+        feature = "reqwest",
+        feature = "fs",
+        any(feature = "aws-base", feature = "gcp-base", feature = "azure-base")
+    ))]
+    #[tokio::test]
+    async fn test_retry_replays_streaming_file_payload() {
+        use crate::{BackoffConfig, PutPayload};
+        use http_body_util::BodyExt;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mock = MockServer::new().await;
+        let request_count = Arc::new(AtomicUsize::new(0));
+        for status in [StatusCode::BAD_GATEWAY, StatusCode::OK] {
+            let request_count = Arc::clone(&request_count);
+            mock.push_async_fn(move |request| async move {
+                request_count.fetch_add(1, Ordering::SeqCst);
+                let body = request.collect().await.unwrap().to_bytes();
+                assert_eq!(body, "streamed payload");
+                Response::builder()
+                    .status(status)
+                    .body(String::new())
+                    .unwrap()
+            });
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("payload");
+        tokio::fs::write(&path, b"streamed payload").await.unwrap();
+        let payload = PutPayload::from_file(path).await.unwrap();
+        let retry = RetryConfig {
+            backoff: BackoffConfig {
+                init_backoff: Duration::from_millis(1),
+                ..Default::default()
+            },
+            max_retries: 1,
+            retry_timeout: Duration::from_secs(10),
+        };
+        let client = HttpClient::new(Client::new());
+
+        let response = client
+            .request(Method::PUT, mock.url())
+            .body(payload.clone())
+            .retryable(&retry)
+            .idempotent(true)
+            .payload(Some(payload))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        mock.shutdown().await;
+    }
+
     #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn test_retry() {

--- a/src/local.rs
+++ b/src/local.rs
@@ -410,6 +410,17 @@ impl ObjectStore for LocalFileSystem {
             });
         }
 
+        let payload = match payload.is_streaming() {
+            true => payload
+                .bytes()
+                .await
+                .map_err(|source| crate::Error::Generic {
+                    store: "LocalFileSystem",
+                    source,
+                })?
+                .into(),
+            false => payload,
+        };
         let path = self.path_to_filesystem(location)?;
         let fsync = self.fsync;
         maybe_spawn_blocking(move || {
@@ -1124,20 +1135,34 @@ impl MultipartUpload for LocalUpload {
         self.offset += data.content_length() as u64;
 
         let s = Arc::clone(&self.state);
-        maybe_spawn_blocking(move || {
-            let mut guard = s.file.lock();
-            let file = guard.as_mut().ok_or(Error::Aborted)?;
-            file.seek(SeekFrom::Start(offset)).map_err(|source| {
-                let path = s.dest.clone();
-                Error::Seek { source, path }
-            })?;
+        async move {
+            let data = match data.is_streaming() {
+                true => data
+                    .bytes()
+                    .await
+                    .map_err(|source| crate::Error::Generic {
+                        store: "LocalFileSystem",
+                        source,
+                    })?
+                    .into(),
+                false => data,
+            };
+            maybe_spawn_blocking(move || {
+                let mut guard = s.file.lock();
+                let file = guard.as_mut().ok_or(Error::Aborted)?;
+                file.seek(SeekFrom::Start(offset)).map_err(|source| {
+                    let path = s.dest.clone();
+                    Error::Seek { source, path }
+                })?;
 
-            data.iter()
-                .try_for_each(|x| file.write_all(x))
-                .map_err(|source| Error::UnableToCopyDataToFile { source })?;
+                data.iter()
+                    .try_for_each(|x| file.write_all(x))
+                    .map_err(|source| Error::UnableToCopyDataToFile { source })?;
 
-            Ok(())
-        })
+                Ok(())
+            })
+            .await
+        }
         .boxed()
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -205,9 +205,16 @@ impl ObjectStore for InMemory {
         payload: PutPayload,
         opts: PutOptions,
     ) -> Result<PutResult> {
+        let payload = payload
+            .bytes()
+            .await
+            .map_err(|source| crate::Error::Generic {
+                store: "InMemory",
+                source,
+            })?;
         let mut storage = self.storage.write();
         let etag = storage.next_etag;
-        let entry = Entry::new(payload.into(), Utc::now(), etag, opts.attributes);
+        let entry = Entry::new(payload, Utc::now(), etag, opts.attributes);
 
         match opts.mode {
             PutMode::Overwrite => storage.overwrite(location, entry),
@@ -450,12 +457,19 @@ impl MultipartStore for InMemory {
         part_idx: usize,
         payload: PutPayload,
     ) -> Result<PartId> {
+        let payload = payload
+            .bytes()
+            .await
+            .map_err(|source| crate::Error::Generic {
+                store: "InMemory",
+                source,
+            })?;
         let mut storage = self.storage.write();
         let upload = storage.upload_mut(id)?;
         if part_idx >= upload.parts.len() {
             upload.parts.resize(part_idx + 1, None);
         }
-        upload.parts[part_idx] = Some(payload.into());
+        upload.parts[part_idx] = Some(payload);
         Ok(PartId {
             content_id: Default::default(),
         })
@@ -538,8 +552,13 @@ impl MultipartUpload for InMemoryUpload {
     async fn complete(&mut self) -> Result<PutResult> {
         let cap = self.parts.iter().map(|x| x.content_length()).sum();
         let mut buf = Vec::with_capacity(cap);
-        let parts = self.parts.iter().flatten();
-        parts.for_each(|x| buf.extend_from_slice(x));
+        for part in &self.parts {
+            let bytes = part.bytes().await.map_err(|source| crate::Error::Generic {
+                store: "InMemory",
+                source,
+            })?;
+            buf.extend_from_slice(&bytes);
+        }
         let etag = self.storage.write().insert(
             &self.location,
             buf.into(),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -20,7 +20,7 @@ use futures_util::Stream;
 use futures_util::stream::{BoxStream, StreamExt};
 use std::error::Error;
 use std::fmt::{Debug, Formatter};
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 use std::path::Path;
 use std::sync::Arc;
 
@@ -33,7 +33,7 @@ pub type PutPayloadStream = BoxStream<'static, Result<Bytes, PutPayloadError>>;
 type StreamFactory = Arc<dyn Fn() -> PutPayloadStream + Send + Sync>;
 
 /// The default chunk size used by [`PutPayload::from_file`].
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 pub const DEFAULT_FILE_CHUNK_SIZE: usize = 16 * 1024;
 
 /// A cheaply cloneable payload for a put request.
@@ -116,7 +116,7 @@ impl PutPayload {
     ///
     /// The file is read in 16 KiB chunks and reopened for every upload attempt.
     /// It must remain available and unchanged until the put request completes.
-    #[cfg(feature = "fs")]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
     pub async fn from_file(path: impl AsRef<Path>) -> std::io::Result<Self> {
         Self::from_file_with_chunk_size(path, DEFAULT_FILE_CHUNK_SIZE).await
     }
@@ -129,7 +129,7 @@ impl PutPayload {
     /// # Panics
     ///
     /// Panics if `chunk_size` is zero.
-    #[cfg(feature = "fs")]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
     pub async fn from_file_with_chunk_size(
         path: impl AsRef<Path>,
         chunk_size: usize,
@@ -237,7 +237,7 @@ impl PutPayload {
     }
 }
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 enum FileStreamState {
     Open(Arc<std::path::PathBuf>),
     Reading(tokio::fs::File),
@@ -487,9 +487,9 @@ impl From<PutPayloadMut> for PutPayload {
 #[cfg(test)]
 mod test {
     use crate::PutPayloadMut;
-    #[cfg(feature = "fs")]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
     use crate::{DEFAULT_FILE_CHUNK_SIZE, PutPayload};
-    #[cfg(feature = "fs")]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
     use futures_util::TryStreamExt;
 
     #[test]
@@ -530,7 +530,7 @@ mod test {
         assert_eq!(payload.content_length(), 148);
     }
 
-    #[cfg(feature = "fs")]
+    #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
     #[tokio::test]
     async fn test_put_payload_from_file() {
         let directory = tempfile::tempdir().unwrap();

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -16,15 +16,61 @@
 // under the License.
 
 use bytes::Bytes;
+use futures_util::Stream;
+use futures_util::stream::{BoxStream, StreamExt};
+use std::error::Error;
+use std::fmt::{Debug, Formatter};
+#[cfg(feature = "fs")]
+use std::path::Path;
 use std::sync::Arc;
 
-/// A cheaply cloneable, ordered collection of [`Bytes`]
-#[derive(Debug, Clone)]
-pub struct PutPayload(Arc<[Bytes]>);
+/// The error type yielded by a streaming [`PutPayload`].
+pub type PutPayloadError = Box<dyn Error + Send + Sync + 'static>;
+
+/// A stream of bytes used by a streaming [`PutPayload`].
+pub type PutPayloadStream = BoxStream<'static, Result<Bytes, PutPayloadError>>;
+
+type StreamFactory = Arc<dyn Fn() -> PutPayloadStream + Send + Sync>;
+
+/// The default chunk size used by [`PutPayload::from_file`].
+#[cfg(feature = "fs")]
+pub const DEFAULT_FILE_CHUNK_SIZE: usize = 16 * 1024;
+
+/// A cheaply cloneable payload for a put request.
+///
+/// A payload can either contain an ordered collection of [`Bytes`] or a
+/// replayable stream with a known content length.
+///
+/// Streaming put support is tracked in
+/// [apache/arrow-rs-object-store#281](https://github.com/apache/arrow-rs-object-store/issues/281).
+#[derive(Clone)]
+pub struct PutPayload(PutPayloadInner);
+
+#[derive(Clone)]
+enum PutPayloadInner {
+    Bytes(Arc<[Bytes]>),
+    Streaming {
+        factory: StreamFactory,
+        content_length: usize,
+    },
+}
+
+impl Debug for PutPayload {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => f.debug_tuple("PutPayload").field(bytes).finish(),
+            PutPayloadInner::Streaming { content_length, .. } => f
+                .debug_struct("PutPayload")
+                .field("streaming", &true)
+                .field("content_length", content_length)
+                .finish(),
+        }
+    }
+}
 
 impl Default for PutPayload {
     fn default() -> Self {
-        Self(Arc::new([]))
+        Self(PutPayloadInner::Bytes(Arc::new([])))
     }
 }
 
@@ -44,20 +90,167 @@ impl PutPayload {
         s.into()
     }
 
-    /// Returns the total length of the [`Bytes`] in this payload
+    /// Creates a replayable streaming [`PutPayload`].
+    ///
+    /// `stream_factory` is invoked for every upload attempt and must return a
+    /// new stream starting at the beginning of the payload. The
+    /// `content_length` must exactly match the number of bytes yielded.
+    pub fn from_stream<F, S, E>(stream_factory: F, content_length: usize) -> Self
+    where
+        F: Fn() -> S + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes, E>> + Send + 'static,
+        E: Error + Send + Sync + 'static,
+    {
+        let factory = Arc::new(move || {
+            stream_factory()
+                .map(|result| result.map_err(|e| Box::new(e) as PutPayloadError))
+                .boxed()
+        });
+        Self(PutPayloadInner::Streaming {
+            factory,
+            content_length,
+        })
+    }
+
+    /// Creates a replayable streaming payload from a file.
+    ///
+    /// The file is read in 16 KiB chunks and reopened for every upload attempt.
+    /// It must remain available and unchanged until the put request completes.
+    #[cfg(feature = "fs")]
+    pub async fn from_file(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        Self::from_file_with_chunk_size(path, DEFAULT_FILE_CHUNK_SIZE).await
+    }
+
+    /// Creates a replayable streaming payload from a file using `chunk_size`.
+    ///
+    /// The file is reopened for every upload attempt. It must remain available
+    /// and unchanged until the put request completes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_size` is zero.
+    #[cfg(feature = "fs")]
+    pub async fn from_file_with_chunk_size(
+        path: impl AsRef<Path>,
+        chunk_size: usize,
+    ) -> std::io::Result<Self> {
+        assert!(chunk_size > 0, "chunk size must be greater than zero");
+
+        let path = Arc::new(path.as_ref().to_owned());
+        let content_length = tokio::fs::metadata(path.as_ref()).await?.len();
+        let content_length = usize::try_from(content_length).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "file length does not fit in usize",
+            )
+        })?;
+
+        Ok(Self::from_stream(
+            move || {
+                let path = Arc::clone(&path);
+                futures_util::stream::try_unfold(
+                    FileStreamState::Open(path),
+                    move |state| async move {
+                        use tokio::io::AsyncReadExt;
+
+                        let mut file = match state {
+                            FileStreamState::Open(path) => {
+                                tokio::fs::File::open(path.as_ref()).await?
+                            }
+                            FileStreamState::Reading(file) => file,
+                        };
+
+                        let mut buffer = vec![0; chunk_size];
+                        let read = file.read(&mut buffer).await?;
+                        if read == 0 {
+                            return Ok::<_, std::io::Error>(None);
+                        }
+                        buffer.truncate(read);
+                        Ok(Some((Bytes::from(buffer), FileStreamState::Reading(file))))
+                    },
+                )
+            },
+            content_length,
+        ))
+    }
+
+    /// Returns the total length of this payload
     pub fn content_length(&self) -> usize {
-        self.0.iter().map(|b| b.len()).sum()
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => bytes.iter().map(|b| b.len()).sum(),
+            PutPayloadInner::Streaming { content_length, .. } => *content_length,
+        }
+    }
+
+    /// Returns `true` if this is a streaming payload.
+    pub fn is_streaming(&self) -> bool {
+        matches!(self.0, PutPayloadInner::Streaming { .. })
+    }
+
+    /// Returns a new stream over this payload.
+    pub fn stream(&self) -> PutPayloadStream {
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => {
+                futures_util::stream::iter(bytes.as_ref().to_vec().into_iter().map(Ok)).boxed()
+            }
+            PutPayloadInner::Streaming { factory, .. } => factory(),
+        }
+    }
+
+    /// Collects this payload into a contiguous [`Bytes`].
+    pub async fn bytes(&self) -> Result<Bytes, PutPayloadError> {
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => Ok(match bytes.len() {
+                0 => Bytes::new(),
+                1 => bytes[0].clone(),
+                _ => {
+                    let mut buffer = Vec::with_capacity(self.content_length());
+                    for chunk in bytes.iter() {
+                        buffer.extend_from_slice(chunk);
+                    }
+                    buffer.into()
+                }
+            }),
+            PutPayloadInner::Streaming { .. } => {
+                let mut stream = self.stream();
+                let mut buffer = Vec::with_capacity(self.content_length());
+                while let Some(chunk) = futures_util::TryStreamExt::try_next(&mut stream).await? {
+                    buffer.extend_from_slice(&chunk);
+                }
+                Ok(buffer.into())
+            }
+        }
     }
 
     /// Returns an iterator over the [`Bytes`] in this payload
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is a streaming payload. Use [`Self::stream`] instead.
     pub fn iter(&self) -> PutPayloadIter<'_> {
-        PutPayloadIter(self.0.iter())
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => PutPayloadIter(bytes.iter()),
+            PutPayloadInner::Streaming { .. } => {
+                panic!("cannot synchronously iterate over a streaming PutPayload")
+            }
+        }
     }
+}
+
+#[cfg(feature = "fs")]
+enum FileStreamState {
+    Open(Arc<std::path::PathBuf>),
+    Reading(tokio::fs::File),
 }
 
 impl AsRef<[Bytes]> for PutPayload {
     fn as_ref(&self) -> &[Bytes] {
-        self.0.as_ref()
+        match &self.0 {
+            PutPayloadInner::Bytes(bytes) => bytes.as_ref(),
+            PutPayloadInner::Streaming { .. } => {
+                panic!("cannot borrow bytes from a streaming PutPayload")
+            }
+        }
     }
 }
 
@@ -109,26 +302,34 @@ impl Iterator for PutPayloadIntoIter {
     type Item = Bytes;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let p = self.payload.0.get(self.idx)?.clone();
+        let p = match &self.payload.0 {
+            PutPayloadInner::Bytes(bytes) => bytes.get(self.idx)?.clone(),
+            PutPayloadInner::Streaming { .. } => {
+                panic!("cannot synchronously iterate over a streaming PutPayload")
+            }
+        };
         self.idx += 1;
         Some(p)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let l = self.payload.0.len() - self.idx;
+        let l = match &self.payload.0 {
+            PutPayloadInner::Bytes(bytes) => bytes.len() - self.idx,
+            PutPayloadInner::Streaming { .. } => 0,
+        };
         (l, Some(l))
     }
 }
 
 impl From<Bytes> for PutPayload {
     fn from(value: Bytes) -> Self {
-        Self(Arc::new([value]))
+        Self(PutPayloadInner::Bytes(Arc::new([value])))
     }
 }
 
 impl From<Vec<u8>> for PutPayload {
     fn from(value: Vec<u8>) -> Self {
-        Self(Arc::new([value.into()]))
+        Self(PutPayloadInner::Bytes(Arc::new([value.into()])))
     }
 }
 
@@ -158,18 +359,24 @@ impl FromIterator<u8> for PutPayload {
 
 impl FromIterator<Bytes> for PutPayload {
     fn from_iter<T: IntoIterator<Item = Bytes>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+        Self(PutPayloadInner::Bytes(iter.into_iter().collect()))
     }
 }
 
 impl From<PutPayload> for Bytes {
     fn from(value: PutPayload) -> Self {
-        match value.0.len() {
+        let bytes = match value.0 {
+            PutPayloadInner::Bytes(bytes) => bytes,
+            PutPayloadInner::Streaming { .. } => {
+                panic!("cannot synchronously collect a streaming PutPayload")
+            }
+        };
+        match bytes.len() {
             0 => Self::new(),
-            1 => value.0[0].clone(),
+            1 => bytes[0].clone(),
             _ => {
-                let mut buf = Vec::with_capacity(value.content_length());
-                value.iter().for_each(|x| buf.extend_from_slice(x));
+                let mut buf = Vec::with_capacity(bytes.iter().map(|x| x.len()).sum());
+                bytes.iter().for_each(|x| buf.extend_from_slice(x));
                 buf.into()
             }
         }
@@ -267,7 +474,7 @@ impl PutPayloadMut {
             let completed = std::mem::take(&mut self.in_progress).into();
             self.completed.push(completed);
         }
-        PutPayload(self.completed.into())
+        PutPayload(PutPayloadInner::Bytes(self.completed.into()))
     }
 }
 
@@ -280,6 +487,10 @@ impl From<PutPayloadMut> for PutPayload {
 #[cfg(test)]
 mod test {
     use crate::PutPayloadMut;
+    #[cfg(feature = "fs")]
+    use crate::{DEFAULT_FILE_CHUNK_SIZE, PutPayload};
+    #[cfg(feature = "fs")]
+    use futures_util::TryStreamExt;
 
     #[test]
     fn test_put_payload() {
@@ -317,5 +528,26 @@ mod test {
         assert_eq!(chunk.content_length(), 148);
         let payload = chunk.freeze();
         assert_eq!(payload.content_length(), 148);
+    }
+
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn test_put_payload_from_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("payload");
+        let data = vec![42; DEFAULT_FILE_CHUNK_SIZE * 2 + 7];
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let payload = PutPayload::from_file(&path).await.unwrap();
+        assert_eq!(payload.content_length(), data.len());
+
+        for _ in 0..2 {
+            let chunks: Vec<_> = payload.stream().try_collect().await.unwrap();
+            assert_eq!(
+                chunks.iter().map(|chunk| chunk.len()).collect::<Vec<_>>(),
+                vec![DEFAULT_FILE_CHUNK_SIZE, DEFAULT_FILE_CHUNK_SIZE, 7]
+            );
+            assert_eq!(chunks.concat(), data);
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #281.

# Rationale for this change

`PutPayload` currently only supports collections of `Bytes`. As a result, uploading a file through `put` or `put_opts` requires loading the entire file into memory or using a multipart upload.

This change allows callers to stream a payload with a known content length through a single PUT request. File-backed payloads are a primary use case.

# What changes are included in this PR?

- Extends `PutPayload` to support replayable streaming bodies with a known content length.
- Adds `PutPayload::from_stream` for constructing streaming payloads.
- Adds `PutPayload::from_file`, which reads files in 16 KiB chunks by default.
- Adds `PutPayload::from_file_with_chunk_size` for configuring the file chunk size.
- Updates HTTP request bodies to poll payload streams asynchronously.
- Recreates the stream for every request attempt so retryable uploads can resend the complete payload.
- Updates S3 signing and checksum calculation to consume streaming payloads.
- Updates the local filesystem and in-memory backends to accept streaming payloads.
- Adds regression tests covering:
  - the default 16 KiB file chunk size;
  - replaying cloned streaming request bodies; and
  - retrying an upload using a file-backed streaming payload.

Validation performed:

- `cargo test`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- compilation with only the `fs` feature
- compilation without default features

# Are there any user-facing changes?

Yes. Callers can now upload a file without first loading the complete file into memory:

```rust
let payload = PutPayload::from_file(file_path).await?;
store.put(&location, payload).await?;
```

Custom streaming payloads can be created with PutPayload::from_stream. The stream factory must produce a new stream from the beginning for every invocation, and the
supplied content length must exactly match the number of bytes yielded.

Existing byte-backed PutPayload construction and iteration behavior is unchanged. Synchronous APIs such as iter, AsRef<[Bytes]>, and conversion into Bytes are not supported for streaming payloads; callers should use PutPayload::stream or PutPayload::bytes instead.

## API compatibility consideration

`PutPayload` remains a public struct backed by a private enum so that existing byte-backed construction and usage remain source compatible:

```rust
enum PutPayloadInner {
    Bytes(Arc<[Bytes]>),
    Streaming {
        factory: StreamFactory,
        content_length: usize,
    },
}
```

There is an API-design limitation around the existing synchronous accessors. Methods and trait implementations such as PutPayload::iter, AsRef<[Bytes]>, IntoIterator, and conversion into Bytes cannot synchronously represent an asynchronous, fallible stream.

In this implementation, their existing behavior is unchanged for byte-backed payloads, but calling them with a streaming payload panics. Streaming-aware implementations should instead use PutPayload::stream or PutPayload::bytes.

Changing the existing synchronous APIs to return Option or Result would avoid the panic but would be a breaking public API change. Returning an empty iterator for streaming payloads was rejected because it could silently result in incomplete uploads.

Feedback from maintainers on the preferred long-term API shape would be appreciated. Possible alternatives include:
- accepting the documented limitation for synchronous APIs;
- changing these APIs in a future breaking release; or
- introducing streaming uploads through a separate payload type or method.