### PR TITLE
docs: clarify S3 builder URL path handling

### DIFF
--- a/src/aws/builder.rs
+++ b/src/aws/builder.rs
@@ -631,12 +631,15 @@ impl AmazonS3Builder {
     ///
     /// Note: Settings derived from the URL will override any others set on this builder
     ///
+    /// A path in the URL is not retained as a prefix. Use [`crate::parse_url`] to create
+    /// an object store and return the path separately.
+    ///
     /// # Example
     /// ```
     /// use object_store::aws::AmazonS3Builder;
     ///
     /// let s3 = AmazonS3Builder::from_env()
-    ///     .with_url("s3://bucket/path")
+    ///     .with_url("s3://bucket")
     ///     .build();
     /// ```
     pub fn with_url(mut self, url: impl Into<String>) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #409.

# Rationale for this change

The AmazonS3Builder::with_url documentation used a path-bearing URL without explaining that the builder applies connection information but does not retain the path as a store prefix. This could lead callers to read from the bucket root unexpectedly.

# What changes are included in this PR?

- Clarify that URL paths are not retained as prefixes.
- Point callers to crate::parse_url when they need both the store and path.
- Use a bucket-only URL in the builder example.

# Are there any user-facing changes?

Documentation only; there is no API or runtime behavior change.

# Validation

- cargo fmt --all --check
- targeted AmazonS3Builder::with_url doctest
- cargo test --doc --all-features (54 passed, 2 ignored)