### PR TITLE
Derive `Clone` for `MicrosoftAzure`

### DIFF
--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -62,7 +62,7 @@ pub use credential::AzureCredential;
 const STORE: &str = "MicrosoftAzure";
 
 /// Interface for [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MicrosoftAzure {
     client: Arc<AzureClient>,
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #824.

# Rationale for this change
 
[All](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3.html#impl-Clone-for-AmazonS3) [other](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorage.html#impl-Clone-for-GoogleCloudStorage) [stores](https://docs.rs/object_store/latest/object_store/local/struct.LocalFileSystem.html#impl-Clone-for-LocalFileSystem) implement `Clone`.

`MicrosoftAzure` should too. It holds the `AzureClient` under an `Arc` so a Clone is very cheap.

# What changes are included in this PR?

Derive `Clone` for `MicrosoftAzure`.

# Are there any user-facing changes?

Adds `Clone`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
