### PR TITLE
Signer: reexport `url::Url` and `http::Method` types in the `signer` module

### DIFF
--- a/src/signer.rs
+++ b/src/signer.rs
@@ -19,9 +19,9 @@
 
 use crate::{Result, path::Path};
 use async_trait::async_trait;
-use http::Method;
+pub use http::Method;
 use std::{fmt, time::Duration};
-use url::Url;
+pub use url::Url;
 
 /// Universal API to generate presigned URLs from multiple object store services.
 #[async_trait]


### PR DESCRIPTION
Minor "ease of use" nit: allow downstream create to not have to explicitly import `url` and `http` crates to use the `Signer` trait

# Rationale for this change

Makes downstream life easier. I had multiple times to add explicit dependencies to these crates just to be able to use the `Signer` trait 

# What changes are included in this PR?

`pub use url::Url` and `pub use http::method::Method` to the `signer` module
