### PR TITLE
Fix MSRV violation in `parse.rs` test, check `--all-targets` in MSRV CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,6 @@ jobs:
       - name: Check
         run: |
           # run `cargo msrv verify` to see problems
-          cargo msrv verify --all-features --output-format=json || exit 1
+          # use a custom check command so tests, examples, and benches are
+          # also compiled with the MSRV toolchain
+          cargo msrv verify --output-format=json -- cargo check --all-targets --all-features || exit 1

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -474,7 +474,7 @@ mod tests {
 
         let res = store.get(&path).await.unwrap();
         let body = res.bytes().await.unwrap();
-        let body = str::from_utf8(&body).unwrap();
+        let body = std::str::from_utf8(&body).unwrap();
         assert_eq!(body, "result");
 
         server.shutdown().await;


### PR DESCRIPTION
# Which issue does this PR close?

N/A — follow-up to a report by @progval in https://github.com/apache/arrow-rs-object-store/pull/812#issuecomment-5061268463

# Rationale for this change

Some things still fail to compile on main with 1.85

```
error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
   --> src/parse.rs:477:25
    |
477 |         let body = str::from_utf8(&body).unwrap();
    |                         ^^^^^^^^^ function or associated item not found in `str`
```

CI did not catch this because the MSRV job runs doesn't check all targeets

# What changes are included in this PR?

1. Update MSRV check to include all targets
1. Fix MSRV 1.85 issues

# Are these changes tested?

Yes by CI
# Are there any user-facing changes?

No, test and CI changes only.