### PR TITLE
Speed up MSRV CI check by installing cargo-msrv via taiki-e/install-action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
       - name: Check
         run: |
           # run `cargo msrv verify` to see problems


### PR DESCRIPTION
# Rationale
- The MSRV check is already the longest CI check
- https://github.com/apache/arrow-rs-object-store/pull/812 makes it even longer (reasonably so)

It would be nice to make this faster

# Changes
Installs `cargo-msrv` as a prebuilt binary via `taiki-e/install-action` (already used for `typos`) instead of compiling it from source with `cargo install`, which dominated the MSRV job's runtime.

## Before this pR
Here is an example from a recent run
https://github.com/apache/arrow-rs-object-store/actions/runs/31621559671/job/95504364705?pr=830

<img width="2093" height="568" alt="Screenshot 2026-08-17 at 5 03 02 PM" src="https://github.com/user-attachments/assets/58d6b234-5982-4d28-a024-ad27cd700425" />

## After this PR
<img width="2109" height="657" alt="Screenshot 2026-08-17 at 5 04 57 PM" src="https://github.com/user-attachments/assets/4690454f-d13e-4461-af4b-88b5ce210d2c" />
(note the actual check takes longer due to https://github.com/apache/arrow-rs-object-store/pull/812)
