### PR TITLE
feat: add `Any` as a supertrait of `ObjectStore`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,6 +801,31 @@ pub type MultipartId = String;
 /// If a store implements [`Clone`], that will only clone the handle to the underlying data. It will NOT clone/fork the
 /// actual key-value data. Hence, the cloned instance and the original instance share the same state.
 ///
+/// # Downcasting
+/// [`Any`] is a supertrait of [`ObjectStore`] so that users can recover the concrete
+/// store behind a `dyn ObjectStore`. This requires nothing from implementors: the
+/// trait already requires `'static`, and [`Any`] is blanket implemented for every
+/// `'static` type.
+///
+/// ```
+/// # use std::any::TypeId;
+/// # use std::sync::Arc;
+/// # use object_store::{ObjectStore, memory::InMemory};
+/// let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+/// assert_eq!(store.as_ref().type_id(), TypeId::of::<InMemory>());
+/// ```
+///
+/// Recovering the concrete type additionally requires a trait object upcast, which
+/// is only available on Rust 1.86 and later (this crate's MSRV is 1.85):
+///
+/// ```ignore
+/// let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+/// let any: Arc<dyn Any + Send + Sync> = store; // requires Rust >= 1.86
+/// let store: Arc<InMemory> = any.downcast().unwrap();
+/// ```
+///
+/// [`Any`]: std::any::Any
+///
 /// # Minimal Default Implementations
 /// There are only a few default implementations for methods in this trait by
 /// design. This was different from versions prior to `0.13.0`, which had many
@@ -905,7 +930,7 @@ pub type MultipartId = String;
 /// ```
 ///
 #[async_trait]
-pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
+pub trait ObjectStore: std::any::Any + std::fmt::Display + Send + Sync + Debug + 'static {
     /// Save the provided `payload` to `location` with the given options
     ///
     /// The operation is guaranteed to be atomic, it will either successfully
@@ -2663,5 +2688,23 @@ mod tests {
         takes_generic_object_store(store);
         let store = Box::new(memory::InMemory::new());
         takes_generic_object_store(store);
+    }
+
+    /// `Any` is a supertrait of `ObjectStore` so downstream crates can recover the
+    /// concrete store behind a `dyn ObjectStore`. Guards against the supertrait
+    /// being dropped.
+    ///
+    /// This only asserts `Any::type_id` because the upcast to `dyn Any` needed for
+    /// `downcast` requires Rust 1.86, above this crate's MSRV.
+    #[test]
+    fn test_dyn_impl_is_any() {
+        use std::any::TypeId;
+
+        let store: Arc<dyn ObjectStore> = Arc::new(memory::InMemory::new());
+        assert_eq!(
+            store.as_ref().type_id(),
+            TypeId::of::<memory::InMemory>(),
+            "type_id of dyn ObjectStore must resolve to the concrete store"
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

None — this is a one-line trait change, so I skipped filing an issue. Happy to open one for changelog purposes if maintainers prefer.

# Rationale for this change

Downstream crates that hold an `Arc<dyn ObjectStore>` sometimes need to recover the concrete store behind it. In DataFusion, stores are registered and later retrieved from an `ObjectStoreRegistry` as `Arc<dyn ObjectStore>`, and there is currently no supported way to get back to the concrete type once it has been erased. The alternatives — an `as_any` method every implementor has to write, or a downstream wrapper trait — both add boilerplate for something the language already gives us.

`ObjectStore` already requires `'static`, and `std::any::Any` is blanket implemented for every `?Sized + 'static` type, so adding `Any` as a supertrait requires no changes from any implementation, in-tree or downstream.

# What changes are included in this PR?

- Add `std::any::Any` to the `ObjectStore` supertrait list.
- Document the new capability under a `# Downcasting` heading on the trait, including the Rust 1.86 caveat below.
- Add `test_dyn_impl_is_any`, alongside the existing `test_dyn_impl` / `test_generic_impl` bound tests, as a regression guard so the supertrait is not silently dropped later.

No implementation in this crate needed changing.

## A note on MSRV

**This PR does not change the MSRV.** Declaring the supertrait compiles on 1.85, and `cargo check` (what the `msrv` CI job runs) passes on 1.85 with this change — verified locally with `cargo +1.85.0 check`.

However, the *trait object upcast* that makes downcasting possible —
`Arc<dyn ObjectStore>` → `Arc<dyn Any + Send + Sync>` — was stabilized in Rust 1.86. So:

- On Rust >= 1.86, users get full `downcast` / `downcast_ref`.
- On Rust 1.85, users only get `Any::type_id` on a `dyn ObjectStore`.

The trait docs state this explicitly, and the upcast example is marked ```` ```ignore ```` so it is not compiled at the current MSRV. The in-crate test asserts `type_id` rather than downcasting, for the same reason.

If maintainers would rather bump the MSRV to 1.86 and document/test the downcast directly, I'm happy to do that instead — say the word.

# Are there any user-facing changes?

Yes, additive:

- `dyn ObjectStore` can now be downcast to the concrete store type (Rust >= 1.86).

On breaking changes: adding a supertrait is technically a public API change, but it should not break anyone in practice. Every existing implementation already satisfies `Any` via the `'static` bound the trait has always required, so no downstream `impl ObjectStore for ...` needs to change. The only theoretical break is method resolution for `type_id`, if a downstream crate has some other trait with a `type_id` method in scope for its store type.

Verified locally: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (no new warnings), `cargo test --all-features --lib`, `cargo test --all-features --doc`, and `cargo +1.85.0 check`.
