### PR TITLE
Restore missing first line of ASF license header in `src/client/s3.rs`

### DIFF
--- a/src/client/s3.rs
+++ b/src/client/s3.rs
@@ -1,3 +1,4 @@
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #853.

# Rationale for this change

The ASF license header in `src/client/s3.rs` is missing its first line 

# What changes are included in this PR?

Restore the missing first line of the standard ASF license header.

# Are there any user-facing changes?

No
