### PR TITLE
Update CHANGELOG for 0.14.2 with latest main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # Changelog
 
-## [v0.14.2](https://github.com/apache/arrow-rs-object-store/tree/v0.14.2) (2026-09-09)
+## [v0.14.2](https://github.com/apache/arrow-rs-object-store/tree/v0.14.2) (2026-09-11)
 
 [Full Changelog](https://github.com/apache/arrow-rs-object-store/compare/v0.14.1...v0.14.2)
 
@@ -33,6 +33,7 @@
 
 **Fixed bugs:**
 
+- Incomplete ASF license header in `src/client/s3.rs` \(caused -1 vote on 0.14.2 RC1\) [\#853](https://github.com/apache/arrow-rs-object-store/issues/853)
 - WriteMultipart::finish should abort after part upload failure [\#818](https://github.com/apache/arrow-rs-object-store/issues/818)
 - The 1.85 MSRV is inaccurate with all features [\#811](https://github.com/apache/arrow-rs-object-store/issues/811)
 - When the backend service returns an HTTP 500, the object store panics [\#414](https://github.com/apache/arrow-rs-object-store/issues/414)
@@ -54,6 +55,7 @@
 
 **Merged pull requests:**
 
+- Restore missing first line of ASF license header in `src/client/s3.rs` [\#854](https://github.com/apache/arrow-rs-object-store/pull/854) ([alamb](https://github.com/alamb))
 - feat: retry failed multipart part uploads [\#849](https://github.com/apache/arrow-rs-object-store/pull/849) ([criccomini](https://github.com/criccomini))
 - build\(deps\): bump taiki-e/install-action from 2.85.5 to 2.86.1 [\#842](https://github.com/apache/arrow-rs-object-store/pull/842) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Restore `UnwindSafe`/`RefUnwindSafe` on `ClientOptions` by bounding `DnsResolver` [\#836](https://github.com/apache/arrow-rs-object-store/pull/836) ([alamb](https://github.com/alamb))


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs-object-store/issues/832

# Rationale for this change

The 0.14.2 RC1 vote received a -1 due to an incomplete ASF license header (https://github.com/apache/arrow-rs-object-store/issues/853), which was fixed in https://github.com/apache/arrow-rs-object-store/pull/854. This PR updates the `CHANGELOG.md` to include that fix, following the pattern from https://github.com/apache/arrow-rs-object-store/pull/850, in preparation for RC2.

# What changes are included in this PR?

Changelog update only, no code changes:
- Add [#853](https://github.com/apache/arrow-rs-object-store/issues/853) to **Fixed bugs**
- Add [#854](https://github.com/apache/arrow-rs-object-store/pull/854) to **Merged pull requests**
- Update the release date to 2026-09-11

# Are these changes tested?

By CI

# Are there any user-facing changes?

No